### PR TITLE
Fix nonexistent key in download example [DEVREL-7]

### DIFF
--- a/docs/files.mdx
+++ b/docs/files.mdx
@@ -273,6 +273,8 @@ def process(file: str, tracer: Tracer):
 Here's a complete example showing how to use the file management API in a typical workflow:
 
 ```python
+from pathlib import Path
+
 async def run(inputs: dict, tracer: Tracer):
     async with await tracer.fs() as fs:
         # List all input files
@@ -291,7 +293,7 @@ async def run(inputs: dict, tracer: Tracer):
             processed_content = process_content(content)
             
             # Create output file
-            output_filename = f"processed_{file_info['name']}"
+            output_filename = f"processed_{Path(file_info['path']).name}"
             with open(f"/tmp/{output_filename}", "wb") as f:
                 f.write(processed_content)
             
@@ -301,7 +303,7 @@ async def run(inputs: dict, tracer: Tracer):
         
         # Clean up temporary files
         for file_info in input_files:
-            if file_info['name'].startswith('temp_'):
+            if Path(file_info['path']).name.startswith('temp_'):
                 await fs.remove(file_info['path'])
 ```
 


### PR DESCRIPTION
## Summary

The `Complete Example` section in `docs/files.mdx` used `file_info['name']` to construct output filenames, but `'name'` is not a valid key of the kodosumi file info dict (which only has `'path'` and `'size'`).

## Changes

- Added `from pathlib import Path` import to the complete example code block
- Replaced `file_info['name']` with `Path(file_info['path']).name` in two places within the `## Complete Example` section of `docs/files.mdx`

This correctly extracts the filename from the `path` field using `pathlib`, which is the idiomatic Python approach.

## Linear Issue

https://linear.app/sokosumi/issue/DEVREL-7