### PR TITLE
Fix typo in landing page card [DEVREL-19]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -121,7 +121,7 @@
     "decoration": "grid"
   },
   "banner": {
-    "content": "Kodosumi and it's documentation are in active development. Please report any issues or feedback to the [GitHub repository](https://github.com/masumi-network/kodosumi).",
+    "content": "Kodosumi and its documentation are in active development. Please report any issues or feedback to the [GitHub repository](https://github.com/masumi-network/kodosumi).",
     "dismissible": true
   },
   "contextual": {


### PR DESCRIPTION
## Summary

The site-wide banner in `docs/docs.json` contained a grammatical error: "it's documentation" (contraction) should be "its documentation" (possessive).

## Changes

- Fixed typo in `docs/docs.json` banner text: changed `"it's documentation"` to `"its documentation"`

The banner text now correctly reads: "Kodosumi and its documentation are in active development."

## Linear Issue

https://linear.app/sokosumi/issue/DEVREL-19