### PR TITLE
feat: surface Ray controller log errors for failed exposes in Admin UI

### DIFF
--- a/kodosumi/service/admin/templates/expose/edit.html
+++ b/kodosumi/service/admin/templates/expose/edit.html
@@ -276,6 +276,52 @@
         color: var(--error);
         padding: 8px 0;
     }
+    .deploy-error {
+        width: 100%;
+        margin-top: 8px;
+        font-size: 0.8rem;
+    }
+    .deploy-error > summary {
+        cursor: pointer;
+        color: #c62828;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        list-style: none;
+    }
+    .deploy-error > summary::-webkit-details-marker { display: none; }
+    .deploy-error > summary i { font-size: 1rem; }
+    .deploy-error pre {
+        margin: 8px 0 0;
+        padding: 10px;
+        background: var(--surface-variant, #1e1e1e);
+        border-radius: 6px;
+        border-left: 3px solid #c62828;
+        max-height: 320px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 0.72rem;
+        line-height: 1.35;
+    }
+    .open-form-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 10px;
+        font-size: 0.8rem;
+        font-weight: 500;
+        color: var(--primary);
+        text-decoration: none;
+        border: 1px solid var(--outline);
+        border-radius: 14px;
+    }
+    .open-form-link:hover {
+        background: rgba(var(--primary-rgb), 0.1);
+        border-color: var(--primary);
+    }
+    .open-form-link i { font-size: 0.95rem; }
 </style>
 <script src="/static/js-yaml.min.js"></script>
 {% endblock %}
@@ -355,6 +401,12 @@
                                     <strong>Heartbeat:</strong>
                                     <span data-timestamp="{{ item.heartbeat }}"></span>
                                 </div>
+                                {% if item.last_error %}
+                                <details class="deploy-error" open>
+                                    <summary><i>error</i> Last deploy error</summary>
+                                    <pre>{{ item.last_error }}</pre>
+                                </details>
+                                {% endif %}
                                 {% endif %}
                             </div>
                         </div>
@@ -422,6 +474,14 @@ deployments:
                                 {% if meta.heartbeat %}
                                 <span style="font-size: 0.8rem;" data-timestamp="{{ meta.heartbeat }}"></span>
                                 {% endif %}
+                                {% endif %}
+                                {% if meta.state == 'alive' %}
+                                <a class="open-form-link" target="_blank" rel="noopener"
+                                   href="/inputs/-/{{ item.name }}{{ meta.url }}"
+                                   title="Open the input form for this flow">
+                                    <i>open_in_new</i>
+                                    <span>Open Form</span>
+                                </a>
                                 {% endif %}
                             </div>
 

--- a/kodosumi/service/admin/templates/expose/main.html
+++ b/kodosumi/service/admin/templates/expose/main.html
@@ -160,6 +160,60 @@
         opacity: 0.6;
         pointer-events: none;
     }
+    .open-form-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 12px;
+    }
+    .open-form-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 10px;
+        font-size: 0.78rem;
+        font-weight: 500;
+        color: var(--primary);
+        text-decoration: none;
+        border: 1px solid var(--outline);
+        border-radius: 14px;
+        transition: all 0.15s ease;
+    }
+    .open-form-link:hover {
+        background: rgba(var(--primary-rgb), 0.1);
+        border-color: var(--primary);
+    }
+    .open-form-link i {
+        font-size: 0.95rem;
+    }
+    .deploy-error {
+        margin-top: 12px;
+        font-size: 0.78rem;
+    }
+    .deploy-error > summary {
+        cursor: pointer;
+        color: #c62828;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        list-style: none;
+    }
+    .deploy-error > summary::-webkit-details-marker { display: none; }
+    .deploy-error > summary i { font-size: 1rem; }
+    .deploy-error pre {
+        margin: 8px 0 0;
+        padding: 10px;
+        background: var(--surface-variant, #1e1e1e);
+        border-radius: 6px;
+        border-left: 3px solid #c62828;
+        max-height: 240px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 0.72rem;
+        line-height: 1.35;
+    }
 </style>
 {% endblock %}
 
@@ -252,6 +306,30 @@
                         </span>
                         {% endif %}
                     </div>
+
+                    {% if item.enabled and item.meta %}
+                    {% set alive_flows = item.meta | selectattr('state', 'equalto', 'alive') | list %}
+                    {% if alive_flows %}
+                    <div class="open-form-row">
+                        {% for meta in alive_flows %}
+                        <a class="open-form-link"
+                           href="/inputs/-/{{ item.name }}{{ meta.url }}"
+                           onclick="event.stopPropagation();"
+                           title="Open the input form for this flow">
+                            <i>open_in_new</i>
+                            <span>Open form{% if alive_flows|length > 1 %} {{ meta.url }}{% endif %}</span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                    {% endif %}
+
+                    {% if item.last_error %}
+                    <details class="deploy-error" onclick="event.stopPropagation();">
+                        <summary><i>error</i> Deploy error — show details</summary>
+                        <pre>{{ item.last_error }}</pre>
+                    </details>
+                    {% endif %}
 
                     {% if item.heartbeat %}
                     <div style="position: absolute; bottom: 12px; right: 12px; font-size: 0.7rem; color: var(--on-surface-variant);"

--- a/kodosumi/service/expose/control.py
+++ b/kodosumi/service/expose/control.py
@@ -6,10 +6,12 @@ All endpoints require operator role authentication.
 
 import asyncio
 import logging
+import os
+import re
 import time
 import uuid
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +93,139 @@ async def get_ray_serve_status(ray_dashboard: str) -> dict:
     except Exception:
         pass
     return {}
+
+
+# Directory where Ray writes its session logs. Override with KODO_RAY_SESSION_DIR
+# if Ray uses a non-default temp dir (e.g. ray start --temp-dir=...).
+RAY_SESSION_DIR = os.environ.get("KODO_RAY_SESSION_DIR", "/tmp/ray/session_latest")
+
+# A Ray log line starts with a level token followed by a timestamp, e.g.
+#   "ERROR 2026-06-03 21:55:34,037 controller 82182 -- ..."
+# We use this to know where one log record (and any attached traceback) ends.
+_RAY_LOG_LINE_RE = re.compile(
+    r"^(INFO|DEBUG|WARNING|ERROR|TRACE|CRITICAL)\s+\d{4}-\d{2}-\d{2}\s"
+)
+
+# Only read the tail of each controller log. The relevant failure is the most
+# recent one, and these files can grow large; reading the whole file on every
+# page render would be wasteful and slow.
+_CONTROLLER_LOG_TAIL_BYTES = 256 * 1024
+
+
+def _read_tail(path: Path, max_bytes: int) -> str:
+    """Read up to the last ``max_bytes`` of a file as text (best-effort)."""
+    with path.open("rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        fh.seek(max(0, size - max_bytes))
+        data = fh.read()
+    return data.decode("utf-8", errors="replace")
+
+
+def _trim_block(block: str, max_chars: int) -> str:
+    """Cap a traceback block, preserving the head and the (more useful) tail."""
+    if len(block) <= max_chars:
+        return block
+    head = block.split("\n", 1)[0]
+    tail = block[-(max_chars - len(head) - 5):]
+    return f"{head}\n...\n{tail}"
+
+
+def get_deploy_errors(
+    names: Sequence[str], max_chars: int = 2500
+) -> Dict[str, Optional[str]]:
+    """
+    Best-effort extraction of the most recent Ray Serve deploy/import error for
+    each of ``names``, scanning the Serve controller logs in a single pass.
+
+    This is the reliable source for *historical* failures: once an app fails to
+    deploy, boot removes it from the Ray Serve config, so it disappears from the
+    live applications API. The controller logs still hold the traceback.
+
+    Each controller log is read (tail only) at most once per call, so rendering
+    a page with many failed exposes stays O(log files), not O(exposes).
+
+    Never raises — returns a mapping of name -> trimmed traceback string (or
+    None when nothing relevant is found / logs are unavailable).
+    """
+    result: Dict[str, Optional[str]] = {name: None for name in names}
+    if not result:
+        return result
+    try:
+        log_dir = Path(RAY_SESSION_DIR) / "logs" / "serve"
+        if not log_dir.is_dir():
+            return result
+
+        marker_map = {
+            name: (
+                f"Exception importing application '{name}'.",
+                f"Deploying app '{name}' failed with exception:",
+            )
+            for name in result
+        }
+
+        # Most recently modified controller logs first.
+        candidates = sorted(
+            log_dir.glob("controller*.log"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+
+        remaining = set(result)
+        for path in candidates:
+            if not remaining:
+                break
+            try:
+                text = _read_tail(path, _CONTROLLER_LOG_TAIL_BYTES)
+            except OSError:
+                continue
+
+            lines = text.splitlines()
+            # Last block seen per name within this file (most recent wins).
+            latest: Dict[str, str] = {}
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                matched = next(
+                    (n for n in remaining
+                     if any(m in line for m in marker_map[n])),
+                    None,
+                )
+                if matched is not None:
+                    block = [line]
+                    i += 1
+                    # Collect following lines until the next log record starts.
+                    while i < len(lines) and not _RAY_LOG_LINE_RE.match(lines[i]):
+                        block.append(lines[i])
+                        i += 1
+                    latest[matched] = "\n".join(block).rstrip()
+                else:
+                    i += 1
+
+            for name, block in latest.items():
+                result[name] = _trim_block(block, max_chars)
+                remaining.discard(name)
+    except Exception:
+        # Diagnostics must never break the page render.
+        pass
+    return result
+
+
+def get_deploy_error(name: str, max_chars: int = 2500) -> Optional[str]:
+    """Single-name convenience wrapper around :func:`get_deploy_errors`."""
+    return get_deploy_errors([name], max_chars).get(name)
+
+
+# Expose states that indicate a deploy/health failure worth surfacing the
+# controller-log traceback for.
+_FAILED_STATES = ("DEPLOY_FAILED", "UNHEALTHY")
+
+
+def is_failed_state(state: Optional[str]) -> bool:
+    """True for states that represent a deploy/health failure."""
+    if not state:
+        return False
+    return state in _FAILED_STATES or "FAIL" in state
 
 
 def ensure_serve_config():
@@ -1118,6 +1253,16 @@ class ExposeUIControl(litestar.Controller):
             else:
                 item.needs_reboot = False
 
+        # Surface the last deploy/import error for failed states so the operator
+        # doesn't have to dig through Ray controller logs. Scan the logs once for
+        # all failed items, off the event loop (blocking file I/O).
+        failed = [it for it in items if is_failed_state(it.state)]
+        if failed:
+            errors = await asyncio.to_thread(
+                get_deploy_errors, [it.name for it in failed])
+            for it in failed:
+                it.last_error = errors.get(it.name)
+
         return Template("expose/main.html", context={"items": items})
 
     @get(
@@ -1149,6 +1294,8 @@ class ExposeUIControl(litestar.Controller):
             raise NotFoundException(detail=f"Expose '{name}' not found")
 
         item = ExposeResponse.from_db_row(row)
+        if is_failed_state(item.state):
+            item.last_error = await asyncio.to_thread(get_deploy_error, item.name)
         return Template("expose/edit.html", context={
             "item": item,
             "is_new": False,

--- a/kodosumi/service/expose/models.py
+++ b/kodosumi/service/expose/models.py
@@ -138,6 +138,7 @@ class ExposeResponse(BaseModel):
     flow_stats: str = "0/0"
     stale: bool = False
     needs_reboot: bool = False
+    last_error: Optional[str] = None  # last deploy/import error (failed states only)
 
     @classmethod
     def from_db_row(cls, row: dict) -> "ExposeResponse":

--- a/tests/test_deploy_error.py
+++ b/tests/test_deploy_error.py
@@ -1,0 +1,125 @@
+"""
+Tests for the deploy-error diagnostics in service.expose.control:
+- is_failed_state()
+- get_deploy_errors() / get_deploy_error()
+"""
+
+import pytest
+
+from kodosumi.service.expose import control
+from kodosumi.service.expose.control import (
+    is_failed_state,
+    get_deploy_error,
+    get_deploy_errors,
+)
+
+
+# --- is_failed_state ------------------------------------------------------
+
+@pytest.mark.parametrize("state,expected", [
+    ("DEPLOY_FAILED", True),
+    ("UNHEALTHY", True),
+    ("DEPLOY_FAILED_PARTIAL", True),  # substring "FAIL"
+    ("RUNNING", False),
+    ("DRAFT", False),
+    ("", False),
+    (None, False),
+])
+def test_is_failed_state(state, expected):
+    assert is_failed_state(state) is expected
+
+
+# --- get_deploy_errors ----------------------------------------------------
+
+def _write_log(tmp_path, monkeypatch, name="controller_1.log", content=""):
+    serve_dir = tmp_path / "logs" / "serve"
+    serve_dir.mkdir(parents=True, exist_ok=True)
+    (serve_dir / name).write_text(content)
+    monkeypatch.setattr(control, "RAY_SESSION_DIR", str(tmp_path))
+    return serve_dir
+
+
+def test_returns_none_when_log_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(control, "RAY_SESSION_DIR", str(tmp_path / "nope"))
+    assert get_deploy_errors(["simple"]) == {"simple": None}
+
+
+def test_extracts_import_error_block(tmp_path, monkeypatch):
+    _write_log(tmp_path, monkeypatch, content=(
+        "INFO 2026-06-03 21:00:00,000 controller 1 -- starting\n"
+        "ERROR 2026-06-03 21:55:34,037 controller 1 -- Exception importing application 'simple'.\n"
+        "Traceback (most recent call last):\n"
+        "  File \"x.py\", line 1, in <module>\n"
+        "    import foo\n"
+        "ModuleNotFoundError: No module named 'foo'\n"
+        "INFO 2026-06-03 21:55:35,000 controller 1 -- next record\n"
+    ))
+
+    out = get_deploy_errors(["simple"])["simple"]
+
+    assert out is not None
+    assert "Exception importing application 'simple'." in out
+    assert "ModuleNotFoundError: No module named 'foo'" in out
+    # Stops at the next log record.
+    assert "next record" not in out
+
+
+def test_single_pass_multiple_names(tmp_path, monkeypatch):
+    _write_log(tmp_path, monkeypatch, content=(
+        "ERROR 2026-06-03 21:55:34,037 controller 1 -- Exception importing application 'alpha'.\n"
+        "boom-alpha\n"
+        "ERROR 2026-06-03 21:55:35,037 controller 1 -- Deploying app 'beta' failed with exception:\n"
+        "boom-beta\n"
+        "INFO 2026-06-03 21:55:36,000 controller 1 -- done\n"
+    ))
+
+    out = get_deploy_errors(["alpha", "beta"])
+
+    assert "boom-alpha" in out["alpha"]
+    assert "boom-beta" in out["beta"]
+
+
+def test_most_recent_block_wins(tmp_path, monkeypatch):
+    _write_log(tmp_path, monkeypatch, content=(
+        "ERROR 2026-06-03 21:00:00,000 controller 1 -- Exception importing application 'simple'.\n"
+        "old-failure\n"
+        "INFO 2026-06-03 21:00:01,000 controller 1 -- retry\n"
+        "ERROR 2026-06-03 22:00:00,000 controller 1 -- Exception importing application 'simple'.\n"
+        "new-failure\n"
+        "INFO 2026-06-03 22:00:01,000 controller 1 -- done\n"
+    ))
+
+    out = get_deploy_errors(["simple"])["simple"]
+
+    assert "new-failure" in out
+    assert "old-failure" not in out
+
+
+def test_truncates_long_block(tmp_path, monkeypatch):
+    head = "ERROR 2026-06-03 21:55:34,037 controller 1 -- Exception importing application 'simple'."
+    body = "\n".join(f"line-{i}" for i in range(5000))
+    _write_log(tmp_path, monkeypatch, content=f"{head}\n{body}\n")
+
+    out = get_deploy_errors(["simple"], max_chars=500)["simple"]
+
+    assert len(out) <= 500
+    assert "..." in out
+    # Head preserved, tail preserved.
+    assert out.startswith(head[:20])
+    assert "line-4999" in out
+
+
+def test_no_match_returns_none(tmp_path, monkeypatch):
+    _write_log(tmp_path, monkeypatch, content=(
+        "INFO 2026-06-03 21:00:00,000 controller 1 -- nothing relevant here\n"
+    ))
+    assert get_deploy_errors(["simple"])["simple"] is None
+
+
+def test_single_name_wrapper(tmp_path, monkeypatch):
+    _write_log(tmp_path, monkeypatch, content=(
+        "ERROR 2026-06-03 21:55:34,037 controller 1 -- Exception importing application 'simple'.\n"
+        "kaboom\n"
+        "INFO 2026-06-03 21:55:35,000 controller 1 -- done\n"
+    ))
+    assert "kaboom" in get_deploy_error("simple")


### PR DESCRIPTION
## Operator pain point
When an expose fails to deploy, boot removes it from the Ray Serve config, so
the failure disappears from the live applications API. The operator is left
with a bare `DEPLOY_FAILED` state in the Admin Panel and no way to see *why* —
diagnosing requires shell access to the host and grepping Ray's controller logs
under `/tmp/ray/session_latest/logs/serve/`. That isn't viable for anyone
operating Kodosumi without direct server access.

## Change
Extract the most recent import/deploy traceback for a failed expose from the
Ray Serve controller logs and surface it inline (collapsed `<details>`) on the
expose list and edit pages.

- Logs are scanned **once per request**, **tail-only** (last 256 KB), and **off
  the event loop** via `asyncio.to_thread`.
- Adds an `is_failed_state()` helper and a `last_error` field on
  `ExposeResponse`.
- Adds "Open Form" links for alive flows.
- The Ray session dir is overridable via `KODO_RAY_SESSION_DIR` for non-default
  temp dirs (e.g. `ray start --temp-dir=...`).

## Tests
`tests/test_deploy_error.py` covers `is_failed_state` and the log extraction
(single-pass multi-name, most-recent-wins, truncation, missing dir).

## Notes
Independent of my other open PRs — reviewable in any order.
