### PR TITLE
fix: sanitize local runtime_env and add hints to serve deploy errors

### DIFF
--- a/kodosumi/service/expose/boot.py
+++ b/kodosumi/service/expose/boot.py
@@ -813,6 +813,66 @@ async def validate_expose_meta(
 # Step A: Deploy Functions
 # =============================================================================
 
+def _augment_serve_error(stderr_text: str, stdout_text: str = "") -> str:
+    """
+    Provide actionable hints for common Ray Serve deploy failures by
+    inspecting stderr/stdout text from the `serve deploy` command.
+
+    This is a best-effort helper and should never raise.
+
+    Args:
+        stderr_text: Text captured from stderr
+        stdout_text: Text captured from stdout
+
+    Returns:
+        Augmented error message string
+    """
+    try:
+        text = (stderr_text or "").strip()
+        combined = f"{stderr_text}\n{stdout_text}" if stdout_text else stderr_text
+
+        # Common case: AttributeError for missing top-level bound attr (e.g., :app)
+        # Example:
+        #   AttributeError: module 'kodosumi_examples.simple' has no attribute 'app'
+        m = re.search(r"AttributeError: module '([^']+)' has no attribute '([^']+)'", combined)
+        if m:
+            module, attr = m.group(1), m.group(2)
+            hint = (
+                f"Ray Serve couldn't find '{attr}' in module '{module}'. "
+                f"Ensure your module defines a top-level bound Serve object named '{attr}', e.g.\n\n"
+                f"    from ray import serve\n"
+                f"    @serve.deployment\n"
+                f"    class App:\n"
+                f"        def __call__(self, request):\n"
+                f"            return {{'hello': 'world'}}\n\n"
+                f"    {attr} = App.bind()\n\n"
+                f"Alternatively, point import_path to the actual exported object (e.g., :graph or :deployment_graph)."
+            )
+            return f"{text}\n\nHINT: {hint}"
+
+        # Runtime env local path rejection when using Serve YAML
+        if "runtime_envs in the Serve config support only remote URIs" in combined:
+            hint = (
+                "Your bootstrap/runtime_env includes a local filesystem path. "
+                "Serve YAML only accepts remote URIs (https://, s3://, gs://). "
+                "Either remove runtime_env.working_dir/py_modules, use a remote URI, "
+                "or install your code into the same virtualenv and reference it via import_path."
+            )
+            return f"{text}\n\nHINT: {hint}"
+
+        # Import path type issues
+        if re.search(r"applications\.[0-9]+\.import_path.*(string|str)", combined, re.IGNORECASE):
+            hint = (
+                "import_path must be a string in the form 'module:attr'. "
+                "For example: kodosumi_examples.simple:app"
+            )
+            return f"{text}\n\nHINT: {hint}"
+
+        return text or combined or "Unknown error from serve deploy"
+    except Exception:
+        # Never fail on augmentation
+        return stderr_text or stdout_text or "Unknown error from serve deploy"
+
 def load_serve_config(config_path: str = RAY_SERVE_CONFIG) -> dict:
     """
     Load and parse serve_config.yaml, create default if missing.
@@ -1071,7 +1131,35 @@ async def _step_deploy(
     async def _submit_current_window() -> Optional[str]:
         """Write temp YAML for all deployed_apps and run serve deploy."""
         window_config = dict(base_config)
-        window_config["applications"] = list(deployed_apps.values())
+        # Sanitize runtime_env to avoid Ray Serve validation errors. Ray Serve
+        # only accepts remote URIs for working_dir / py_modules when provided via
+        # Serve YAML; local filesystem paths (e.g. /Users/..) cause pydantic
+        # validation errors, so strip non-remote paths here. runtime_env is
+        # copied first so we never mutate the shared deployed_apps entries.
+        sanitized_apps = []
+        for app in deployed_apps.values():
+            a = dict(app)
+            try:
+                rt = a.get("runtime_env")
+                if isinstance(rt, dict):
+                    rt = dict(rt)
+                    # Drop local working_dir
+                    wd = rt.get("working_dir")
+                    if isinstance(wd, str) and not re.match(r"^(s3|s3a|gs|https?)://", wd):
+                        rt.pop("working_dir", None)
+                    # Drop any local paths from py_modules (keep only remote URIs)
+                    pmods = rt.get("py_modules")
+                    if isinstance(pmods, list):
+                        rt["py_modules"] = [m for m in pmods if isinstance(m, str) and re.match(r"^(s3|s3a|gs|https?)://", m)]
+                        if not rt["py_modules"]:
+                            rt.pop("py_modules", None)
+                    a["runtime_env"] = rt
+            except Exception:
+                # Best-effort sanitization — never fail boot due to this logic
+                pass
+            sanitized_apps.append(a)
+
+        window_config["applications"] = sanitized_apps
         try:
             with tempfile.NamedTemporaryFile(
                 mode="w", suffix=".yaml", delete=False, prefix="serve_deploy_"
@@ -1094,7 +1182,9 @@ async def _step_deploy(
                 pass
 
         if returncode != 0:
-            return stderr.strip() if stderr else f"Exit code {returncode}"
+            # Provide user-friendly hints for common failures
+            augmented = _augment_serve_error(stderr, stdout)
+            return augmented if augmented else (stderr.strip() if stderr else f"Exit code {returncode}")
         return None
 
     # --- Discover which apps are already deployed in Ray Serve ---
@@ -1258,9 +1348,10 @@ async def _step_deploy(
         deployed_apps = all_app_configs
         error = await _submit_current_window()
         if error:
+            # Standardize error wording to match earlier deploy failures
             yield BootMessage(
-                step=BootStep.DEPLOY, msg_type=MessageType.WARNING,
-                message=f"Final deploy (re-adding failed apps) failed: {error}",
+                step=BootStep.DEPLOY, msg_type=MessageType.ERROR,
+                message=f"serve deploy failed: {error}",
                 progress=progress
             )
         else:
@@ -1766,6 +1857,50 @@ async def _step_register_flows(
         )
         return
 
+    # First: Ask Admin Panel to import all Serve routes in bulk
+    registered_count = 0
+    routes_url = f"{ray_serve_address.rstrip('/')}/-/routes"
+    try:
+        async with httpx.AsyncClient(timeout=30.0, cookies=auth_cookies) as client:
+            resp = await client.post(
+                f"{app_server.rstrip('/')}/flow/register",
+                json={"url": routes_url},
+            )
+            if resp.status_code == 200:
+                try:
+                    payload = resp.json() or []
+                    if isinstance(payload, list):
+                        registered_count = len(payload)
+                    else:
+                        registered_count = 0
+                except Exception:
+                    registered_count = 0
+                yield BootMessage(
+                    step=BootStep.REGISTER,
+                    msg_type=MessageType.ACTIVITY,
+                    message="Registered flows from routes",
+                    target="/-/routes",
+                    result=f"{registered_count} registered",
+                    progress=progress,
+                )
+            else:
+                yield BootMessage(
+                    step=BootStep.REGISTER,
+                    msg_type=MessageType.WARNING,
+                    message="Flow registration failed",
+                    target="/-/routes",
+                    result=f"HTTP {resp.status_code}",
+                    progress=progress,
+                )
+    except Exception as e:
+        yield BootMessage(
+            step=BootStep.REGISTER,
+            msg_type=MessageType.WARNING,
+            message=f"Flow registration error: {e}",
+            target="/-/routes",
+            progress=progress,
+        )
+
     # Discover flows from each app's OpenAPI — parallel (batch of 4)
     all_flows: List[DiscoveredFlow] = []
     batch_size = BOOT_BATCH_SIZE  # reuse same concurrency limit
@@ -1828,7 +1963,7 @@ async def _step_register_flows(
     yield BootMessage(
         step=BootStep.REGISTER,
         msg_type=MessageType.STEP_END,
-        message=f"Flow registration complete ({len(all_flows)} discovered)",
+        message=f"Flow registration complete ({registered_count} registered, {len(all_flows)} discovered)",
         progress=progress,
         data={"discovered_flows": all_flows}
     )

--- a/tests/test_boot_step_a.py
+++ b/tests/test_boot_step_a.py
@@ -20,6 +20,7 @@ from kodosumi.service.expose.boot import (
     load_serve_config,
     parse_bootstrap,
     run_serve_deploy,
+    _augment_serve_error,
     _step_deploy,
     BootStep,
     MessageType,
@@ -150,6 +151,40 @@ route_prefix: /original-route
 
         assert result["name"] == "new-name"
         assert result["route_prefix"] == "/new-name"
+
+
+class TestAugmentServeError:
+    """Tests for _augment_serve_error() hint generation."""
+
+    def test_attribute_error_hint(self):
+        stderr = (
+            "AttributeError: module 'kodosumi_examples.simple' has no attribute 'app'"
+        )
+        out = _augment_serve_error(stderr)
+        assert "HINT:" in out
+        assert "App.bind()" in out
+        # Original error text is preserved.
+        assert "has no attribute 'app'" in out
+
+    def test_local_runtime_env_hint(self):
+        stderr = "runtime_envs in the Serve config support only remote URIs"
+        out = _augment_serve_error(stderr)
+        assert "HINT:" in out
+        assert "remote URIs" in out
+
+    def test_unknown_error_passthrough(self):
+        stderr = "some totally unrecognized failure"
+        out = _augment_serve_error(stderr)
+        assert out.strip() == "some totally unrecognized failure"
+
+    def test_import_path_type_hint(self):
+        stderr = "applications.0.import_path: Input should be a valid string"
+        out = _augment_serve_error(stderr)
+        assert "HINT:" in out
+        assert "module:attr" in out
+
+    def test_never_raises_on_empty(self):
+        assert _augment_serve_error("", "") == "Unknown error from serve deploy"
 
 
 class TestRunServeDeploy:
@@ -416,3 +451,63 @@ class TestStepDeployIntegration:
             # Verify progress updated
             assert progress.step_name == "Deploy"
             assert progress.activities_done > 0
+
+    @pytest.mark.asyncio
+    async def test_strips_local_runtime_env_before_deploy(self):
+        """Local working_dir/py_modules should be stripped from runtime_env; remote URIs kept."""
+        deploy_configs = []
+        real_yaml_dump = yaml.dump
+
+        def capturing_yaml_dump(data, stream=None, **kwargs):
+            # Capture every config that contains a non-empty applications list —
+            # that's the per-window deploy payload, not the base config write.
+            if isinstance(data, dict) and data.get("applications"):
+                deploy_configs.append(data)
+            return real_yaml_dump(data, stream, **kwargs)
+
+        with patch("kodosumi.service.expose.boot.db") as mock_db, \
+             patch("kodosumi.service.expose.boot.run_serve_deploy") as mock_deploy, \
+             patch("kodosumi.service.expose.boot.load_serve_config") as mock_config, \
+             patch("kodosumi.service.expose.boot.yaml.dump", side_effect=capturing_yaml_dump):
+
+            mock_db.init_database = AsyncMock()
+            mock_db.get_all_exposes = AsyncMock(return_value=[{
+                "name": "my-app",
+                "enabled": True,
+                "bootstrap": (
+                    "import_path: mymod:app\n"
+                    "runtime_env:\n"
+                    "  working_dir: /local/path\n"
+                    "  pip:\n"
+                    "    - requests\n"
+                    "  py_modules:\n"
+                    "    - /local/module\n"
+                    "    - https://remote.example.com/pkg.zip\n"
+                ),
+            }])
+            mock_config.return_value = {"applications": []}
+            mock_deploy.return_value = (0, "success", "")
+
+            progress = BootProgress()
+            async for _ in _step_deploy(progress):
+                pass
+
+        assert deploy_configs, "yaml.dump was never called with a non-empty applications list"
+        app = deploy_configs[0]["applications"][0]
+        rt = app.get("runtime_env", {})
+
+        # Local paths must be gone.
+        assert "working_dir" not in rt, "local working_dir should be stripped"
+        assert "/local/module" not in rt.get("py_modules", []), "local py_module should be stripped"
+
+        # Remote URI must survive.
+        assert "https://remote.example.com/pkg.zip" in rt.get("py_modules", []), "remote py_module should be kept"
+
+        # Unrelated keys must be untouched.
+        assert "pip" in rt, "pip should not be stripped"
+
+        # The original deployed_apps entry must not be mutated.
+        # (Verifies the deep-copy fix — if shallow copy, rt would be empty here.)
+        mock_exposes = mock_db.get_all_exposes.return_value
+        original_rt = yaml.safe_load(mock_exposes[0]["bootstrap"]).get("runtime_env", {})
+        assert "working_dir" in original_rt, "original bootstrap must remain unmutated"


### PR DESCRIPTION
## Operator pain point
Two recurring boot failures are hard to diagnose today:

1. A bootstrap with a local `runtime_env.working_dir` (or local `py_modules`)
   makes `serve deploy` fail pydantic validation — Ray Serve YAML only accepts
   remote URIs there — and the surfaced error is opaque.
2. A wrong `import_path` attribute (e.g. `:app` not defined) produces a raw Ray
   traceback with no guidance.

## Change
- Strip local `working_dir` / `py_modules` from `runtime_env` before writing the
  deploy YAML. `runtime_env` is copied first, so the shared `deployed_apps`
  entries are never mutated across deploy windows.
- Augment common `serve deploy` failures (missing bound attribute, local
  runtime_env, import_path type) with actionable `HINT:` messages.
- Register flows from `/-/routes` in bulk during the register step and report
  the registered count alongside discovered flows.

## Tests
Extends `tests/test_boot_step_a.py` with `_augment_serve_error` coverage and a
runtime_env-stripping integration test (which also guards against the
shared-mutation regression).

## Notes
Independent of my other open PRs — reviewable in any order. The silent strip is
intentional for resilience; happy to emit a WARNING boot message instead if
maintainers prefer.
