### PR TITLE
fix(expose): name the real reason a selling wallet list is empty

### DIFF
--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -247,6 +247,7 @@ async function openMigrateDialog(idx) {
     var errEl = document.getElementById('mig_error');
 
     document.getElementById('mig_deregister').checked = false;
+    document.getElementById('mig_api_base_url').value = '';
     submitBtn.disabled = true;
     errEl.style.display = 'none';
     document.getElementById('migrate-dialog').showModal();
@@ -309,6 +310,8 @@ async function submitMigration() {
                 flow_url: flowUrl,
                 wallet_vkey: walletSelect.value,
                 deregister_previous: document.getElementById('mig_deregister').checked,
+                api_base_url:
+                    document.getElementById('mig_api_base_url').value.trim(),
                 meta_yaml: metaYaml,
                 meta_etag: etag ? etag.value : null
             })

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -271,8 +271,7 @@ async function openMigrateDialog(idx) {
     // register dialog on the same section leaves it pointing at idx while
     // this dialog is shut, and the reason below would go into a hidden
     // element instead of onto the page.
-    if (!document.getElementById('migrate-dialog').open ||
-            activeDialogIdx !== idx) {
+    if (!document.getElementById('migrate-dialog').open) {
         // The dialog was closed while the list loaded. Quiet kept the
         // reason off the page, so hand it back now: an unreachable node
         // must not look like nothing having happened.
@@ -297,6 +296,10 @@ async function openMigrateDialog(idx) {
               walletLoadError
             : 'No Web3CardanoV2 selling wallet on this network. ' +
               'Add one in the Masumi payment service first.';
+        // Not redundant with the disable at the top of this function. A
+        // submitMigration started before this open re-enables the button
+        // in its finally, and that can land while this load is running,
+        // so the button has to be taken back here.
         submitBtn.disabled = true;
     } else {
         // The offered wallets are real even when another source failed, so

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -208,7 +208,14 @@ async function submitRegistration() {
 
 // ─── Migrate Dialog ─────────────────────────────────────────────
 
+// Counts every open of the migrate dialog. Closing and reopening the same
+// flow leaves activeDialogIdx unchanged, so that check alone cannot retire
+// the first open: its late wallet load would append a second copy of the
+// options the second open already rendered.
+let migrateDialogGeneration = 0;
+
 async function openMigrateDialog(idx) {
+    var generation = ++migrateDialogGeneration;
     hideRegError(idx);
     activeDialogIdx = idx;
 
@@ -254,26 +261,35 @@ async function openMigrateDialog(idx) {
 
     // Read the wallet list again. The operator may have added the V2
     // payment source after this page loaded, and the copy from page init
-    // would then claim a wallet that exists is missing.
-    await loadWallets();
-    if (activeDialogIdx !== idx) return;
+    // would then claim a wallet that exists is missing. Quiet, because
+    // this dialog shows the reason itself and must not leave a standing
+    // error on registry sections that are working.
+    await loadWallets({quiet: true});
+    if (generation !== migrateDialogGeneration || activeDialogIdx !== idx) {
+        return;
+    }
 
     var v2Wallets = loadedWallets.filter(function(w) {
         return w.paymentSourceType === 'Web3CardanoV2';
     });
     if (v2Wallets.length === 0) {
         errEl.style.display = 'block';
-        // Only a list that actually loaded can prove a V2 wallet is
-        // missing. When the load itself failed, the node's own reason is
-        // the answer, and blaming a missing wallet sends the operator
-        // looking for the wrong thing.
+        // Only a list that loaded in full can prove a V2 wallet is missing.
+        // A failed load, and a list with a failed request behind it, both
+        // set walletLoadError: report that instead, or the operator goes
+        // looking for a wallet that a transient error merely hid.
         errEl.textContent = walletLoadError
-            ? 'No selling wallet could be listed. ' + walletLoadError
+            ? 'No Web3CardanoV2 selling wallet could be listed. ' +
+              walletLoadError
             : 'No Web3CardanoV2 selling wallet on this network. ' +
               'Add one in the Masumi payment service first.';
         submitBtn.disabled = true;
     } else {
-        errEl.style.display = 'none';
+        // The offered wallets are real even when another source failed, so
+        // the migration may go ahead. Say that one is missing, in case the
+        // operator is looking for it.
+        errEl.style.display = walletLoadError ? 'block' : 'none';
+        errEl.textContent = walletLoadError || '';
         submitBtn.disabled = false;
         v2Wallets.forEach(function(w) {
             var opt = document.createElement('option');

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -352,6 +352,7 @@ async function submitMigration() {
                 return;
             }
             errEl.style.display = 'block';
+            errEl.style.color = '';
             errEl.textContent = data.detail || 'Migration failed';
             return;
         }
@@ -396,6 +397,7 @@ async function submitMigration() {
             return;
         }
         errEl.style.display = 'block';
+        errEl.style.color = '';
         errEl.textContent = 'Network error: ' + e.message;
         await checkRegistryStatus(idx, flowUrl);
     } finally {

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -265,7 +265,14 @@ async function openMigrateDialog(idx) {
     // this dialog shows the reason itself and must not leave a standing
     // error on registry sections that are working.
     await loadWallets({quiet: true});
-    if (generation !== migrateDialogGeneration || activeDialogIdx !== idx) {
+    if (generation !== migrateDialogGeneration) return;
+    if (activeDialogIdx !== idx) {
+        // The dialog was closed while the list loaded. Quiet kept the
+        // reason off the page, so hand it back now: an unreachable node
+        // must not look like nothing having happened.
+        if (walletLoadError) {
+            showWalletInfo(walletLoadError, walletLoadIsWarning);
+        }
         return;
     }
 
@@ -278,6 +285,7 @@ async function openMigrateDialog(idx) {
         // A failed load, and a list with a failed request behind it, both
         // set walletLoadError: report that instead, or the operator goes
         // looking for a wallet that a transient error merely hid.
+        errEl.style.color = '';
         errEl.textContent = walletLoadError
             ? 'No Web3CardanoV2 selling wallet could be listed. ' +
               walletLoadError
@@ -287,9 +295,12 @@ async function openMigrateDialog(idx) {
     } else {
         // The offered wallets are real even when another source failed, so
         // the migration may go ahead. Say that one is missing, in case the
-        // operator is looking for it.
+        // operator is looking for it, but not in the colour that means
+        // "you cannot continue".
         errEl.style.display = walletLoadError ? 'block' : 'none';
         errEl.textContent = walletLoadError || '';
+        errEl.style.color = walletLoadIsWarning
+            ? 'var(--on-surface-variant)' : '';
         submitBtn.disabled = false;
         v2Wallets.forEach(function(w) {
             var opt = document.createElement('option');

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -266,7 +266,13 @@ async function openMigrateDialog(idx) {
     // error on registry sections that are working.
     await loadWallets({quiet: true});
     if (generation !== migrateDialogGeneration) return;
-    if (activeDialogIdx !== idx) {
+    // Ask the dialog whether it is still open. activeDialogIdx belongs to
+    // both dialogs, so an operator who closes this one and opens the
+    // register dialog on the same section leaves it pointing at idx while
+    // this dialog is shut, and the reason below would go into a hidden
+    // element instead of onto the page.
+    if (!document.getElementById('migrate-dialog').open ||
+            activeDialogIdx !== idx) {
         // The dialog was closed while the list loaded. Quiet kept the
         // reason off the page, so hand it back now: an unreachable node
         // must not look like nothing having happened.

--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -208,7 +208,7 @@ async function submitRegistration() {
 
 // ─── Migrate Dialog ─────────────────────────────────────────────
 
-function openMigrateDialog(idx) {
+async function openMigrateDialog(idx) {
     hideRegError(idx);
     activeDialogIdx = idx;
 
@@ -243,15 +243,33 @@ function openMigrateDialog(idx) {
 
     var select = document.getElementById('mig_wallet');
     select.innerHTML = '';
+    var submitBtn = document.getElementById('mig_submit');
+    var errEl = document.getElementById('mig_error');
+
+    document.getElementById('mig_deregister').checked = false;
+    submitBtn.disabled = true;
+    errEl.style.display = 'none';
+    document.getElementById('migrate-dialog').showModal();
+
+    // Read the wallet list again. The operator may have added the V2
+    // payment source after this page loaded, and the copy from page init
+    // would then claim a wallet that exists is missing.
+    await loadWallets();
+    if (activeDialogIdx !== idx) return;
+
     var v2Wallets = loadedWallets.filter(function(w) {
         return w.paymentSourceType === 'Web3CardanoV2';
     });
-    var submitBtn = document.getElementById('mig_submit');
-    var errEl = document.getElementById('mig_error');
     if (v2Wallets.length === 0) {
         errEl.style.display = 'block';
-        errEl.textContent = 'No Web3CardanoV2 selling wallet on this network. ' +
-            'Add one in the Masumi payment service first.';
+        // Only a list that actually loaded can prove a V2 wallet is
+        // missing. When the load itself failed, the node's own reason is
+        // the answer, and blaming a missing wallet sends the operator
+        // looking for the wrong thing.
+        errEl.textContent = walletLoadError
+            ? 'No selling wallet could be listed. ' + walletLoadError
+            : 'No Web3CardanoV2 selling wallet on this network. ' +
+              'Add one in the Masumi payment service first.';
         submitBtn.disabled = true;
     } else {
         errEl.style.display = 'none';
@@ -263,9 +281,6 @@ function openMigrateDialog(idx) {
             select.appendChild(opt);
         });
     }
-
-    document.getElementById('mig_deregister').checked = false;
-    document.getElementById('migrate-dialog').showModal();
 }
 
 async function submitMigration() {

--- a/kodosumi/service/admin/templates/expose/_registry_dialogs.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialogs.html
@@ -30,13 +30,26 @@
             <select id="mig_wallet"></select>
         </div>
         <div class="dialog-field">
+            <label>API base URL (optional)</label>
+            <input type="text" id="mig_api_base_url"
+                   placeholder="Leave empty to keep the URL of the V1 listing">
+            <div class="dialog-readonly" style="font-size: 0.75rem;">
+                The new agent advertises the same URL as the V1 listing unless
+                you set one here. Only set it when another deployment serves
+                the V2 agent: this kodosumi answers on its own path, so a
+                different value is minted on chain and sends buyers elsewhere.
+            </div>
+        </div>
+        <div class="dialog-field">
             <label style="display:flex; align-items:center; gap:8px; text-transform:none;">
                 <input type="checkbox" id="mig_deregister" style="width:auto; margin:0;">
                 <span>Deregister the V1 agent once the new one is confirmed</span>
             </label>
             <div class="dialog-readonly" style="font-size: 0.75rem;">
-                Leave this off to stay listed on both rails. The V1 agent is
-                then kept in the flow metadata and can be deregistered later.
+                Leave this off to keep the V1 agent on chain for a manual burn
+                later. It stays discoverable, but this flow serves one
+                registration: after the switch every job is priced and paid on
+                V2, even for a buyer who found the V1 listing.
             </div>
         </div>
         <div class="dlg-error" id="mig_error" style="display:none;"></div>

--- a/kodosumi/service/admin/templates/expose/_registry_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_script.html
@@ -5,8 +5,6 @@ let activeDialogIdx = null;
 const pollIntervals = {};
 const pollInFlight = {};
 const registryRequestGenerations = {};
-// The migrate dialog offers V2 wallets only, so keep the fetched list.
-let loadedWallets = [];
 
 function beginRegistryRequest(idx) {
     var generation = (registryRequestGenerations[idx] || 0) + 1;
@@ -114,70 +112,6 @@ function updateRegistryVisibility() {
                 info.style.display = 'none';
                 info.textContent = '';
             }
-        }
-    });
-}
-
-async function loadWallets() {
-    if (!exposeName) return;
-    try {
-        const resp = await fetch('/expose/' + exposeName + '/wallets', {
-            credentials: 'same-origin'
-        });
-        if (!resp.ok) {
-            console.error('Wallets endpoint returned', resp.status);
-            showWalletInfo('Wallets could not be loaded (HTTP ' + resp.status + ')');
-            return;
-        }
-        const data = await resp.json();
-
-        if (data.error) {
-            showWalletInfo(data.error);
-            return;
-        }
-
-        const wallets = data.wallets || [];
-        loadedWallets = wallets;
-        if (wallets.length === 0) {
-            showWalletInfo('No selling wallets found for this network.');
-            return;
-        }
-
-        // Populate all wallet select elements (use class selector, not id prefix)
-        document.querySelectorAll('select.wallet-select').forEach(function(sel) {
-            var current = sel.value;
-            sel.innerHTML = '<option value="">Select wallet...</option>';
-            wallets.forEach(function(w) {
-                var vk = w.walletVkey;
-                var shortId = vk.substring(0, 6) + '\u2026' + vk.substring(vk.length - 6);
-                var label = w.note ? w.note + ' (' + shortId + ')' : shortId;
-                // The wallet selects the registration version, so name it.
-                if (w.paymentSourceType === 'Web3CardanoV2') {
-                    label += ' [V2]';
-                } else if (w.paymentSourceType === 'Web3CardanoV1') {
-                    label += ' [V1]';
-                }
-                var opt = document.createElement('option');
-                opt.value = vk;
-                opt.textContent = label;
-                if (vk === current) opt.selected = true;
-                sel.appendChild(opt);
-            });
-        });
-    } catch (e) {
-        console.error('Failed to load wallets:', e);
-        showWalletInfo('Failed to load wallets: ' + e.message);
-    }
-}
-
-function showWalletInfo(msg) {
-    document.querySelectorAll('.registry-section').forEach(function(section) {
-        var idx = section.id.replace('registry_', '');
-        var info = document.getElementById('reg_info_' + idx);
-        if (info) {
-            info.style.display = 'block';
-            info.textContent = msg;
-            info.style.color = 'var(--error)';
         }
     });
 }
@@ -626,7 +560,6 @@ async function cancelMigration(idx) {
         await checkRegistryStatus(idx, flowUrl);
     }
 }
-
 
 // ─── Polling ────────────────────────────────────────────────────
 

--- a/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
@@ -10,6 +10,17 @@ let walletLoadError = '';
 // Whether that reason still leaves a usable list. A caution painted in the
 // error colour reads as a refusal, and an operator who can act stops.
 let walletLoadIsWarning = false;
+// Which load owns the three variables above. They are shared, and an
+// answer that arrives after a newer load started would otherwise write
+// over it: an abandoned load could refill the list a failed reload had
+// just cleared, and the dialog would offer a wallet the node no longer
+// reports, with Submit enabled, beside the words "could not be loaded".
+let walletLoadGeneration = 0;
+// What showWalletInfo last put on the registry sections. Only that exact
+// text may be taken down again, because updateRegistryUI writes the same
+// elements and a wallet message must not wipe a status line it did not
+// write.
+let walletInfoOnPage = '';
 
 // options.quiet keeps a failure out of the registry sections. The migrate
 // dialog reloads on every open and shows the reason in its own error line,
@@ -17,12 +28,17 @@ let walletLoadIsWarning = false;
 // section of the page and leave it there until a reload.
 async function loadWallets(options) {
     var quiet = !!(options && options.quiet);
+    var generation;
+    function retired() {
+        return generation !== walletLoadGeneration;
+    }
     function report(message, soft) {
         walletLoadError = message;
         walletLoadIsWarning = !!soft;
         if (!quiet) showWalletInfo(message, soft);
     }
     if (!exposeName) return;
+    generation = ++walletLoadGeneration;
     // A failed reload must not leave the previous list standing. The
     // migrate dialog mints against what it finds here, so a stale entry
     // would be minted against a wallet this node no longer reports.
@@ -33,12 +49,14 @@ async function loadWallets(options) {
         const resp = await fetch('/expose/' + exposeName + '/wallets', {
             credentials: 'same-origin'
         });
+        if (retired()) return;
         if (!resp.ok) {
             console.error('Wallets endpoint returned', resp.status);
             report('Wallets could not be loaded (HTTP ' + resp.status + ').');
             return;
         }
         const data = await resp.json();
+        if (retired()) return;
 
         if (data.error) {
             report(data.error);
@@ -51,6 +69,9 @@ async function loadWallets(options) {
             report('No selling wallets found for this network.');
             return;
         }
+        // A good load has to take down the message a bad one left, on
+        // every section, including flows the operator never opened.
+        clearWalletInfo();
         // A list can arrive non-empty and still be short of a wallet whose
         // payment source could not be read. Keep the list, keep the reason.
         if (data.warning) {
@@ -80,12 +101,14 @@ async function loadWallets(options) {
             });
         });
     } catch (e) {
+        if (retired()) return;
         console.error('Failed to load wallets:', e);
         report('Failed to load wallets: ' + e.message);
     }
 }
 
 function showWalletInfo(msg, soft) {
+    walletInfoOnPage = msg;
     document.querySelectorAll('.registry-section').forEach(function(section) {
         var idx = section.id.replace('registry_', '');
         var info = document.getElementById('reg_info_' + idx);
@@ -94,6 +117,25 @@ function showWalletInfo(msg, soft) {
             info.textContent = msg;
             info.style.color = soft
                 ? 'var(--on-surface-variant)' : 'var(--error)';
+        }
+    });
+}
+
+// Take down the wallet message, and only that. Nothing else clears it:
+// hideRegError works on reg_error_<idx>, a different element, and the
+// idle branch of updateRegistryUI only clears its own sentences. So a
+// failed load used to leave every section red until a full reload.
+function clearWalletInfo() {
+    if (!walletInfoOnPage) return;
+    var previous = walletInfoOnPage;
+    walletInfoOnPage = '';
+    document.querySelectorAll('.registry-section').forEach(function(section) {
+        var idx = section.id.replace('registry_', '');
+        var info = document.getElementById('reg_info_' + idx);
+        if (info && info.textContent === previous) {
+            info.textContent = '';
+            info.style.display = 'none';
+            info.style.color = '';
         }
     });
 }

--- a/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
@@ -8,7 +8,16 @@ let loadedWallets = [];
 // at from its length.
 let walletLoadError = '';
 
-async function loadWallets() {
+// options.quiet keeps a failure out of the registry sections. The migrate
+// dialog reloads on every open and shows the reason in its own error line,
+// so without this one blip while opening it would paint red text on every
+// section of the page and leave it there until a reload.
+async function loadWallets(options) {
+    var quiet = !!(options && options.quiet);
+    function report(message) {
+        walletLoadError = message;
+        if (!quiet) showWalletInfo(message);
+    }
     if (!exposeName) return;
     // A failed reload must not leave the previous list standing. The
     // migrate dialog mints against what it finds here, so a stale entry
@@ -21,25 +30,26 @@ async function loadWallets() {
         });
         if (!resp.ok) {
             console.error('Wallets endpoint returned', resp.status);
-            walletLoadError =
-                'Wallets could not be loaded (HTTP ' + resp.status + ').';
-            showWalletInfo(walletLoadError);
+            report('Wallets could not be loaded (HTTP ' + resp.status + ').');
             return;
         }
         const data = await resp.json();
 
         if (data.error) {
-            walletLoadError = data.error;
-            showWalletInfo(data.error);
+            report(data.error);
             return;
         }
 
         const wallets = data.wallets || [];
         loadedWallets = wallets;
         if (wallets.length === 0) {
-            walletLoadError = 'No selling wallets found for this network.';
-            showWalletInfo(walletLoadError);
+            report('No selling wallets found for this network.');
             return;
+        }
+        // A list can arrive non-empty and still be short of a wallet whose
+        // payment source could not be read. Keep the list, keep the reason.
+        if (data.warning) {
+            report(data.warning);
         }
 
         // Populate all wallet select elements (use class selector, not id prefix)
@@ -65,8 +75,7 @@ async function loadWallets() {
         });
     } catch (e) {
         console.error('Failed to load wallets:', e);
-        walletLoadError = 'Failed to load wallets: ' + e.message;
-        showWalletInfo(walletLoadError);
+        report('Failed to load wallets: ' + e.message);
     }
 }
 

--- a/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
@@ -7,6 +7,9 @@ let loadedWallets = [];
 // apart, so the reason travels with the list instead of being guessed
 // at from its length.
 let walletLoadError = '';
+// Whether that reason still leaves a usable list. A caution painted in the
+// error colour reads as a refusal, and an operator who can act stops.
+let walletLoadIsWarning = false;
 
 // options.quiet keeps a failure out of the registry sections. The migrate
 // dialog reloads on every open and shows the reason in its own error line,
@@ -14,9 +17,10 @@ let walletLoadError = '';
 // section of the page and leave it there until a reload.
 async function loadWallets(options) {
     var quiet = !!(options && options.quiet);
-    function report(message) {
+    function report(message, soft) {
         walletLoadError = message;
-        if (!quiet) showWalletInfo(message);
+        walletLoadIsWarning = !!soft;
+        if (!quiet) showWalletInfo(message, soft);
     }
     if (!exposeName) return;
     // A failed reload must not leave the previous list standing. The
@@ -24,6 +28,7 @@ async function loadWallets(options) {
     // would be minted against a wallet this node no longer reports.
     loadedWallets = [];
     walletLoadError = '';
+    walletLoadIsWarning = false;
     try {
         const resp = await fetch('/expose/' + exposeName + '/wallets', {
             credentials: 'same-origin'
@@ -49,7 +54,8 @@ async function loadWallets(options) {
         // A list can arrive non-empty and still be short of a wallet whose
         // payment source could not be read. Keep the list, keep the reason.
         if (data.warning) {
-            report(data.warning);
+            // The list is usable, so this is a caution, not a refusal.
+            report(data.warning, true);
         }
 
         // Populate all wallet select elements (use class selector, not id prefix)
@@ -79,14 +85,15 @@ async function loadWallets(options) {
     }
 }
 
-function showWalletInfo(msg) {
+function showWalletInfo(msg, soft) {
     document.querySelectorAll('.registry-section').forEach(function(section) {
         var idx = section.id.replace('registry_', '');
         var info = document.getElementById('reg_info_' + idx);
         if (info) {
             info.style.display = 'block';
             info.textContent = msg;
-            info.style.color = 'var(--error)';
+            info.style.color = soft
+                ? 'var(--on-surface-variant)' : 'var(--error)';
         }
     });
 }

--- a/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_wallets_script.html
@@ -1,0 +1,83 @@
+// ─── Wallet Discovery ───────────────────────────────────────────
+
+// The migrate dialog offers V2 wallets only, so keep the fetched list.
+let loadedWallets = [];
+// Why the last load produced no usable list. An empty list has several
+// causes, and a dialog that only counts the entries cannot tell them
+// apart, so the reason travels with the list instead of being guessed
+// at from its length.
+let walletLoadError = '';
+
+async function loadWallets() {
+    if (!exposeName) return;
+    // A failed reload must not leave the previous list standing. The
+    // migrate dialog mints against what it finds here, so a stale entry
+    // would be minted against a wallet this node no longer reports.
+    loadedWallets = [];
+    walletLoadError = '';
+    try {
+        const resp = await fetch('/expose/' + exposeName + '/wallets', {
+            credentials: 'same-origin'
+        });
+        if (!resp.ok) {
+            console.error('Wallets endpoint returned', resp.status);
+            walletLoadError =
+                'Wallets could not be loaded (HTTP ' + resp.status + ').';
+            showWalletInfo(walletLoadError);
+            return;
+        }
+        const data = await resp.json();
+
+        if (data.error) {
+            walletLoadError = data.error;
+            showWalletInfo(data.error);
+            return;
+        }
+
+        const wallets = data.wallets || [];
+        loadedWallets = wallets;
+        if (wallets.length === 0) {
+            walletLoadError = 'No selling wallets found for this network.';
+            showWalletInfo(walletLoadError);
+            return;
+        }
+
+        // Populate all wallet select elements (use class selector, not id prefix)
+        document.querySelectorAll('select.wallet-select').forEach(function(sel) {
+            var current = sel.value;
+            sel.innerHTML = '<option value="">Select wallet...</option>';
+            wallets.forEach(function(w) {
+                var vk = w.walletVkey;
+                var shortId = vk.substring(0, 6) + '…' + vk.substring(vk.length - 6);
+                var label = w.note ? w.note + ' (' + shortId + ')' : shortId;
+                // The wallet selects the registration version, so name it.
+                if (w.paymentSourceType === 'Web3CardanoV2') {
+                    label += ' [V2]';
+                } else if (w.paymentSourceType === 'Web3CardanoV1') {
+                    label += ' [V1]';
+                }
+                var opt = document.createElement('option');
+                opt.value = vk;
+                opt.textContent = label;
+                if (vk === current) opt.selected = true;
+                sel.appendChild(opt);
+            });
+        });
+    } catch (e) {
+        console.error('Failed to load wallets:', e);
+        walletLoadError = 'Failed to load wallets: ' + e.message;
+        showWalletInfo(walletLoadError);
+    }
+}
+
+function showWalletInfo(msg) {
+    document.querySelectorAll('.registry-section').forEach(function(section) {
+        var idx = section.id.replace('registry_', '');
+        var info = document.getElementById('reg_info_' + idx);
+        if (info) {
+            info.style.display = 'block';
+            info.textContent = msg;
+            info.style.color = 'var(--error)';
+        }
+    });
+}

--- a/kodosumi/service/admin/templates/expose/edit.html
+++ b/kodosumi/service/admin/templates/expose/edit.html
@@ -513,6 +513,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initRegistrySections();
 });
 
+{% include "expose/_registry_wallets_script.html" %}
 {% include "expose/_registry_script.html" %}
 {% include "expose/_registry_dialog_script.html" %}
 {% endblock %}

--- a/kodosumi/service/admin/templates/expose/edit.html
+++ b/kodosumi/service/admin/templates/expose/edit.html
@@ -176,7 +176,7 @@
                         <div class="s12 l6">
                             <div class="field border label">
                                 <input type="text" id="name" name="name" required
-                                       pattern="^[a-z0-9][a-z0-9_-]*$"
+                                       pattern="^[a-z0-9][a-z0-9_\-]*$"
                                        value="{{ duplicate_name if duplicate_name else (item.name if item else '') }}">
                                 <label>Name</label>
                             </div>

--- a/kodosumi/service/expose/currency.py
+++ b/kodosumi/service/expose/currency.py
@@ -1,0 +1,44 @@
+"""Currency units a Masumi price is expressed in.
+
+An amount travels in base units on chain and in human units in the flow
+YAML, and the asset is named by a hex unit string that differs per
+network. Keeping the mapping here leaves the registry client with one
+job, reading and writing registrations.
+"""
+
+from typing import Dict
+
+# Currency mapping: human-readable → hex unit on-chain
+CURRENCY_UNITS: Dict[str, Dict[str, str]] = {
+    "USDM": {
+        "Preprod": "16a55b2a349361ff88c03788f93e1e966e5d689605d044fef722ddde0014df10745553444d",
+        "Mainnet": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d",
+    },
+    "ADA": {
+        "Preprod": "",
+        "Mainnet": "",
+    },
+}
+
+# All currencies have 6 decimal places
+CURRENCY_DECIMALS = 6
+
+
+def human_to_base_amount(amount: float) -> str:
+    """Convert human-readable amount (e.g. 0.01) to base units string (e.g. '10000')."""
+    base = round(amount * (10 ** CURRENCY_DECIMALS))
+    return str(base)
+
+
+def base_to_human_amount(base_amount: str) -> float:
+    """Convert base units string (e.g. '10000') to human-readable amount (e.g. 0.01)."""
+    return int(base_amount) / (10 ** CURRENCY_DECIMALS)
+
+
+def unit_to_currency(unit: str) -> str:
+    """Map hex unit string back to human-readable currency name."""
+    for currency, networks in CURRENCY_UNITS.items():
+        for network, hex_unit in networks.items():
+            if hex_unit == unit:
+                return currency
+    return "ADA" if unit == "" else "unknown"

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -36,6 +36,14 @@ from kodosumi.service.jwt import operator_guard
 logger = logging.getLogger(__name__)
 
 
+# What a host may hold. urlparse is not the parser that will fetch this
+# url, and the two disagree outside these sets, so a character outside
+# them is refused rather than guessed at. A host outside ASCII has to be
+# entered in its punycode form, which is what DNS carries anyway.
+HOST_CHARACTERS = set("abcdefghijklmnopqrstuvwxyz0123456789.-")
+IPV6_CHARACTERS = set("0123456789abcdef:.")
+
+
 def _is_absolute_http_url(value: str) -> bool:
     """Accept only a url a buyer can actually call.
 
@@ -48,8 +56,20 @@ def _is_absolute_http_url(value: str) -> bool:
     both have one and neither has a host. An invisible character is the
     same kind of trap, because a zero width space survives a copy out of a
     document and cannot be seen in the field afterwards.
+
+    The parser here is not the parser that fetches the url. urlparse reads
+    RFC 3986 and every client reads the WHATWG url standard, and the two
+    disagree about a backslash and about a host outside ASCII. To urlparse
+    the host of "https://good.com\\@evil.com" is evil.com; to a browser it
+    is good.com. Approving one host and handing a buyer the other is worse
+    than refusing, because the mint is permanent, so only the shapes both
+    parsers read the same way are accepted.
     """
     if not value.isprintable() or any(c.isspace() for c in value):
+        return False
+    # A client reads a backslash in the authority as a separator. urlparse
+    # reads it as one more character of the host.
+    if "\\" in value:
         return False
     try:
         parsed = urlparse(value)
@@ -59,13 +79,17 @@ def _is_absolute_http_url(value: str) -> bool:
         return False
     if parsed.scheme.lower() not in ("http", "https") or not host:
         return False
+    # A user name or a password here would be minted into a public
+    # registry entry that nobody can edit afterwards.
+    if parsed.username or parsed.password:
+        return False
+    allowed = IPV6_CHARACTERS if parsed.netloc.startswith("[") \
+        else HOST_CHARACTERS
+    if not set(host) <= allowed:
+        return False
     # "http://." and "http://-" have a host by the parser's reckoning and
     # resolve for nobody, which is what a mistyped paste looks like.
-    if not any(character.isalnum() for character in host):
-        return False
-    # Percent encoding in a host is a paste artefact, except in the zone id
-    # of a bracketed IPv6 literal, where it is how the zone is written.
-    return "%" not in host or parsed.netloc.startswith("[")
+    return any(character.isalnum() for character in host)
 
 
 class RegistryMigrateControl(litestar.Controller):
@@ -124,7 +148,12 @@ class RegistryMigrateControl(litestar.Controller):
             raise ClientException(
                 detail="wallet_vkey is required", status_code=422)
 
-        api_base_url_override = data.get("api_base_url") or ""
+        # Read the raw value before any falsy default. "or" would turn 0,
+        # False and [] into "" and drop them silently, on a field that
+        # decides an irreversible mint.
+        api_base_url_override = data.get("api_base_url")
+        if api_base_url_override is None:
+            api_base_url_override = ""
         if not isinstance(api_base_url_override, str):
             raise ClientException(
                 detail="api_base_url must be a string",

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -10,6 +10,7 @@ All endpoints require operator role authentication.
 """
 
 import logging
+from urllib.parse import urlparse
 
 import litestar
 from litestar import post
@@ -33,6 +34,23 @@ from kodosumi.service.expose.registration import (build_agent_fields,
 from kodosumi.service.jwt import operator_guard
 
 logger = logging.getLogger(__name__)
+
+
+def _is_absolute_http_url(value: str) -> bool:
+    """Accept only a url a buyer can actually call.
+
+    A prefix check is not enough. "http://" alone, and a value with a space
+    or a newline in it, both pass one and are useless on chain, where the
+    mint cannot be taken back. The scheme is case insensitive per RFC 3986,
+    so HTTPS:// is a legal url and must not be refused.
+    """
+    if value != value.strip() or any(c.isspace() for c in value):
+        return False
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return False
+    return parsed.scheme.lower() in ("http", "https") and bool(parsed.netloc)
 
 
 class RegistryMigrateControl(litestar.Controller):
@@ -91,12 +109,19 @@ class RegistryMigrateControl(litestar.Controller):
             raise ClientException(
                 detail="wallet_vkey is required", status_code=422)
 
-        api_base_url_override = (data.get("api_base_url") or "").strip()
-        if api_base_url_override and not api_base_url_override.startswith(
-                ("http://", "https://")):
+        api_base_url_override = data.get("api_base_url") or ""
+        if not isinstance(api_base_url_override, str):
             raise ClientException(
-                detail="api_base_url must start with http:// or https://. "
-                       "The value is minted on chain, so a relative or "
+                detail="api_base_url must be a string",
+                status_code=422,
+            )
+        api_base_url_override = api_base_url_override.strip()
+        if api_base_url_override and not _is_absolute_http_url(
+                api_base_url_override):
+            raise ClientException(
+                detail="api_base_url must be an absolute http:// or https:// "
+                       "url with a host. The value is minted on chain and "
+                       "kodosumi cannot update a registration, so a "
                        "malformed url cannot be corrected from here.",
                 status_code=422,
             )

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -54,9 +54,18 @@ def _is_absolute_http_url(value: str) -> bool:
     try:
         parsed = urlparse(value)
         host = parsed.hostname
+        parsed.port  # raises when the port is not a number in range
     except ValueError:
         return False
-    return parsed.scheme.lower() in ("http", "https") and bool(host)
+    if parsed.scheme.lower() not in ("http", "https") or not host:
+        return False
+    # "http://." and "http://-" have a host by the parser's reckoning and
+    # resolve for nobody, which is what a mistyped paste looks like.
+    if not any(character.isalnum() for character in host):
+        return False
+    # Percent encoding in a host is a paste artefact, except in the zone id
+    # of a bracketed IPv6 literal, where it is how the zone is written.
+    return "%" not in host or parsed.netloc.startswith("[")
 
 
 class RegistryMigrateControl(litestar.Controller):

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -56,6 +56,10 @@ class RegistryMigrateControl(litestar.Controller):
             flow_url: str - Flow URL path (e.g. /myapp/analyze)
             wallet_vkey: str - Selling wallet of a Web3CardanoV2 source
             deregister_previous: bool - burn the V1 agent once V2 confirms
+            api_base_url: str - url the new agent advertises (optional). It
+                defaults to the url of the V1 listing, which is what a
+                single deployment wants. Set it only when another
+                deployment serves the V2 agent.
             meta_yaml: str - live YAML of the flow (optional)
         """
         await db.init_database()
@@ -86,6 +90,16 @@ class RegistryMigrateControl(litestar.Controller):
         if not wallet_vkey:
             raise ClientException(
                 detail="wallet_vkey is required", status_code=422)
+
+        api_base_url_override = (data.get("api_base_url") or "").strip()
+        if api_base_url_override and not api_base_url_override.startswith(
+                ("http://", "https://")):
+            raise ClientException(
+                detail="api_base_url must start with http:// or https://. "
+                       "The value is minted on chain, so a relative or "
+                       "malformed url cannot be corrected from here.",
+                status_code=422,
+            )
 
         deregister_previous = data.get("deregister_previous", False)
         if not isinstance(deregister_previous, bool):
@@ -224,7 +238,7 @@ class RegistryMigrateControl(litestar.Controller):
                     masumi=masumi,
                     name=fields["name"],
                     description=fields["description"],
-                    api_base_url=sumi_api_base_url(
+                    api_base_url=api_base_url_override or sumi_api_base_url(
                         state["settings"].sumi_address, flow_url),
                     tags=fields["tags"],
                     pricing=None,

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -43,14 +43,20 @@ def _is_absolute_http_url(value: str) -> bool:
     or a newline in it, both pass one and are useless on chain, where the
     mint cannot be taken back. The scheme is case insensitive per RFC 3986,
     so HTTPS:// is a legal url and must not be refused.
+
+    A non-empty netloc is not enough either: "http://:8080" and "http://@"
+    both have one and neither has a host. An invisible character is the
+    same kind of trap, because a zero width space survives a copy out of a
+    document and cannot be seen in the field afterwards.
     """
-    if value != value.strip() or any(c.isspace() for c in value):
+    if not value.isprintable() or any(c.isspace() for c in value):
         return False
     try:
         parsed = urlparse(value)
+        host = parsed.hostname
     except ValueError:
         return False
-    return parsed.scheme.lower() in ("http", "https") and bool(parsed.netloc)
+    return parsed.scheme.lower() in ("http", "https") and bool(host)
 
 
 class RegistryMigrateControl(litestar.Controller):

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -40,8 +40,29 @@ logger = logging.getLogger(__name__)
 # url, and the two disagree outside these sets, so a character outside
 # them is refused rather than guessed at. A host outside ASCII has to be
 # entered in its punycode form, which is what DNS carries anyway.
-HOST_CHARACTERS = set("abcdefghijklmnopqrstuvwxyz0123456789.-")
+HOST_CHARACTERS = set("abcdefghijklmnopqrstuvwxyz0123456789.-_")
 IPV6_CHARACTERS = set("0123456789abcdef:.")
+
+
+def _is_dotted_quad(host: str) -> bool:
+    """True for the one spelling of an IPv4 address both parsers agree on.
+
+    A client reads any host whose last label is a number as an address,
+    and reads it in whatever base the digits imply. urlparse never does,
+    so "0177.0.0.1" is a name here and 127.0.0.1 there. Only the plain
+    decimal form with no leading zero means the same thing to both.
+    """
+    labels = host.split(".")
+    if len(labels) != 4:
+        return False
+    for label in labels:
+        if not label.isdigit():
+            return False
+        if label != "0" and label.startswith("0"):
+            return False
+        if int(label) > 255:
+            return False
+    return True
 
 
 def _is_absolute_http_url(value: str) -> bool:
@@ -59,11 +80,15 @@ def _is_absolute_http_url(value: str) -> bool:
 
     The parser here is not the parser that fetches the url. urlparse reads
     RFC 3986 and every client reads the WHATWG url standard, and the two
-    disagree about a backslash and about a host outside ASCII. To urlparse
-    the host of "https://good.com\\@evil.com" is evil.com; to a browser it
-    is good.com. Approving one host and handing a buyer the other is worse
-    than refusing, because the mint is permanent, so only the shapes both
+    disagree about a backslash, about a host outside ASCII, and about a
+    host whose last label is a number. To urlparse the host of
+    "https://good.com\\@evil.com" is evil.com; to a browser it is good.com.
+    Approving one host and handing a buyer the other is worse than
+    refusing, because the mint is permanent, so only the shapes both
     parsers read the same way are accepted.
+
+    An underscore is not one of the disagreements. Both parsers keep it,
+    RFC 2181 allows it, and compose deployments use it, so it stays.
     """
     if not value.isprintable() or any(c.isspace() for c in value):
         return False
@@ -83,9 +108,19 @@ def _is_absolute_http_url(value: str) -> bool:
     # registry entry that nobody can edit afterwards.
     if parsed.username or parsed.password:
         return False
-    allowed = IPV6_CHARACTERS if parsed.netloc.startswith("[") \
-        else HOST_CHARACTERS
-    if not set(host) <= allowed:
+    if parsed.netloc.startswith("["):
+        return (set(host) <= IPV6_CHARACTERS
+                and any(character.isalnum() for character in host))
+    if not set(host) <= HOST_CHARACTERS:
+        return False
+    # A last label that is a number turns the whole host into an address
+    # for a client and leaves it a name for urlparse. "0177.0.0.1" is a
+    # public address here and loopback there, and "api.example.123" is a
+    # host here and a parse error there, so a number may only appear in
+    # the one form both read alike.
+    last_label = host.rsplit(".", 1)[-1]
+    if ((last_label.isdigit() or last_label.startswith("0x"))
+            and not _is_dotted_quad(host)):
         return False
     # "http://." and "http://-" have a host by the parser's reckoning and
     # resolve for nobody, which is what a mistyped paste looks like.

--- a/kodosumi/service/expose/migrate_control.py
+++ b/kodosumi/service/expose/migrate_control.py
@@ -118,7 +118,12 @@ def _is_absolute_http_url(value: str) -> bool:
     # public address here and loopback there, and "api.example.123" is a
     # host here and a parse error there, so a number may only appear in
     # the one form both read alike.
-    last_label = host.rsplit(".", 1)[-1]
+    # Strip the root dot before reading the last label. "example.com."
+    # is a legitimate fully qualified name that both parsers keep, but
+    # without this the last label is "" and the whole number rule below
+    # is skipped: "http://0177.0.0.1." was minted, and a client resolves
+    # it to 127.0.0.1.
+    last_label = host.rstrip(".").rsplit(".", 1)[-1]
     if ((last_label.isdigit() or last_label.startswith("0x"))
             and not _is_dotted_quad(host)):
         return False

--- a/kodosumi/service/expose/pricing.py
+++ b/kodosumi/service/expose/pricing.py
@@ -1,0 +1,212 @@
+"""
+Pricing translation between flow YAML and the Masumi registry.
+
+A registration carries its price in the shape the payment source
+expects: a V1 entry prices the agent once, a V2 entry prices every
+supported payment source on its own. These functions move a price
+between the operator's YAML and either shape, and refuse the values the
+payment node would reject with an opaque 400.
+"""
+
+from typing import Any, Dict, List
+
+from kodosumi.service.expose.currency import (CURRENCY_DECIMALS,
+                                              CURRENCY_UNITS,
+                                              human_to_base_amount,
+                                              unit_to_currency)
+
+# Masumi payment source types. A payment source is the deployed escrow
+# contract a selling wallet belongs to, and it decides the registration
+# shape: V1 entries carry top-level AgentPricing, V2 entries carry a
+# supportedPaymentSources list that prices every source on its own.
+PAYMENT_SOURCE_TYPE_V1 = "Web3CardanoV1"
+PAYMENT_SOURCE_TYPE_V2 = "Web3CardanoV2"
+
+# Index into supportedPaymentSources that Kodosumi registers and pays with.
+# Kodosumi advertises exactly one source per agent, so the index is always 0.
+DEFAULT_SUPPORTED_PAYMENT_SOURCE_INDEX = 0
+
+# Bounds the payment node enforces on a V2 registration. Checking them here
+# turns an opaque 400 from the node into a message that names the flow YAML
+# field the operator has to correct.
+MIN_FIXED_PRICING_ENTRIES = 1
+MAX_FIXED_PRICING_ENTRIES = 5
+# The node bounds the amount string at 19 characters and parses it into a
+# Postgres bigint, so leading zeros count and the value has a ceiling.
+MAX_ATOMIC_AMOUNT_DIGITS = 19
+MAX_ATOMIC_AMOUNT = 9223372036854775807
+
+
+def pricing_yaml_to_registry(pricing_yaml: Any, network: str) -> Dict:
+    """
+    Convert Kodosumi YAML pricing format to Masumi Registry API format.
+
+    YAML format:
+        agentPricing:
+          - pricingType: Fixed
+            fixedPricing:
+              - amount: "10000"
+                unit: "16a55b2a..."
+
+    Registry format:
+        {"pricingType": "Fixed", "Pricing": [{"amount": "10000", "unit": "16a55b2a..."}]}
+
+    Raises ValueError when the YAML is not one of the shapes above. The
+    metadata is hand edited, so a mapping or a scalar reaches this function
+    and must become a message the operator can act on, not a KeyError.
+    """
+    if not pricing_yaml:
+        return {"pricingType": "Free"}
+
+    # A single mapping is the shape operators write most often by mistake.
+    if isinstance(pricing_yaml, dict):
+        pricing_yaml = [pricing_yaml]
+    if not isinstance(pricing_yaml, list) or not isinstance(
+            pricing_yaml[0], dict):
+        raise ValueError(
+            "agentPricing must be a list of pricing entries, for example: "
+            "agentPricing:\n  - pricingType: Free"
+        )
+
+    first = pricing_yaml[0]
+    pricing_type = first.get("pricingType", "Free")
+
+    if pricing_type == "Free":
+        return {"pricingType": "Free"}
+
+    fixed_pricing = first.get("fixedPricing") or []
+    if not isinstance(fixed_pricing, list):
+        raise ValueError(
+            "agentPricing[0].fixedPricing must be a list of "
+            "{amount, unit} entries")
+    registry_pricing = []
+    for p in fixed_pricing:
+        if not isinstance(p, dict):
+            raise ValueError(
+                "Every agentPricing[0].fixedPricing entry must be a mapping "
+                "with an amount and a unit")
+        unit = p.get("unit", "")
+        # Convert "lovelace" to empty string for registry
+        if unit == "lovelace":
+            unit = ""
+        registry_pricing.append({
+            "amount": str(p.get("amount", "0")),
+            "unit": unit,
+        })
+
+    return {
+        "pricingType": "Fixed",
+        "Pricing": registry_pricing,
+    }
+
+
+def pricing_to_yaml_format(pricing_type: str, amount: float, currency: str, network: str) -> List[Dict]:
+    """
+    Convert UI pricing input to Kodosumi YAML format.
+
+    Returns list suitable for agentPricing in meta YAML.
+    """
+    if pricing_type == "Free":
+        return [{"pricingType": "Free"}]
+
+    unit_hex = CURRENCY_UNITS.get(currency, {}).get(network, "")
+    base_amount = human_to_base_amount(amount)
+
+    return [{
+        "pricingType": "Fixed",
+        "fixedPricing": [{
+            "amount": base_amount,
+            "unit": unit_hex,
+        }],
+    }]
+
+
+def _atomic_amount(amount: Any) -> str:
+    """
+    Render one price as the atomic amount string the payment node accepts.
+
+    The node takes digits only, at most 19 characters of them, and rejects
+    zero. A missing amount used to default to "0" and was refused on chain
+    with an error that never named the flow YAML.
+
+    The result is normalised, so leading zeros written in the YAML cannot
+    push an otherwise valid amount past the node's 19 character bound.
+    """
+    text = str(amount if amount is not None else "").strip()
+    if not text.isdigit() or int(text) <= 0:
+        raise ValueError(
+            f"Pricing amount must be a positive whole number of base units, "
+            f"got '{amount}'."
+        )
+    value = int(text)
+    if value > MAX_ATOMIC_AMOUNT:
+        raise ValueError(
+            f"Pricing amount is above the largest amount the payment node "
+            f"stores ({MAX_ATOMIC_AMOUNT}): '{amount}'."
+        )
+    normalised = str(value)
+    if len(normalised) > MAX_ATOMIC_AMOUNT_DIGITS:
+        raise ValueError(
+            f"Pricing amount has more than {MAX_ATOMIC_AMOUNT_DIGITS} digits: "
+            f"'{amount}'."
+        )
+    return normalised
+
+
+def registry_pricing_to_supported_sources(
+    registry_pricing: Dict,
+    network: str,
+    smart_contract_address: str,
+) -> List[Dict]:
+    """
+    Convert V1 registry pricing into the V2 supportedPaymentSources list.
+
+    V2 registrations reject the top-level AgentPricing field. Each entry in
+    supportedPaymentSources names one escrow contract and owns its price.
+    Kodosumi advertises the single contract the selling wallet belongs to.
+
+    Registry format (V1):
+        {"pricingType": "Fixed", "Pricing": [{"amount": "10000", "unit": ""}]}
+
+    Supported source format (V2):
+        [{"chain": "Cardano", "network": "Preprod",
+          "paymentSourceType": "Web3CardanoV2", "address": "addr_test1...",
+          "pricing": {"pricingType": "Fixed",
+                      "fixed": [{"asset": "", "amount": "10000"}]}}]
+    """
+    if not smart_contract_address:
+        raise ValueError(
+            "V2 registration requires the smart contract address of the "
+            "selling wallet payment source"
+        )
+
+    pricing_type = registry_pricing.get("pricingType", "Free")
+    if pricing_type == "Fixed":
+        pricing: Dict[str, Any] = {
+            "pricingType": "Fixed",
+            "fixed": [
+                {
+                    "asset": price.get("unit", ""),
+                    "amount": _atomic_amount(price.get("amount")),
+                }
+                for price in registry_pricing.get("Pricing") or []
+            ],
+        }
+        entry_count = len(pricing["fixed"])
+        if not (MIN_FIXED_PRICING_ENTRIES <= entry_count
+                <= MAX_FIXED_PRICING_ENTRIES):
+            raise ValueError(
+                f"Fixed pricing needs between {MIN_FIXED_PRICING_ENTRIES} and "
+                f"{MAX_FIXED_PRICING_ENTRIES} priced assets, got "
+                f"{entry_count}. Add fixedPricing entries to agentPricing."
+            )
+    else:
+        pricing = {"pricingType": pricing_type}
+
+    return [{
+        "chain": "Cardano",
+        "network": network,
+        "paymentSourceType": PAYMENT_SOURCE_TYPE_V2,
+        "address": smart_contract_address,
+        "pricing": pricing,
+    }]

--- a/kodosumi/service/expose/pricing.py
+++ b/kodosumi/service/expose/pricing.py
@@ -10,10 +10,8 @@ payment node would reject with an opaque 400.
 
 from typing import Any, Dict, List
 
-from kodosumi.service.expose.currency import (CURRENCY_DECIMALS,
-                                              CURRENCY_UNITS,
-                                              human_to_base_amount,
-                                              unit_to_currency)
+from kodosumi.service.expose.currency import (CURRENCY_UNITS,
+                                              human_to_base_amount)
 
 # Masumi payment source types. A payment source is the deployed escrow
 # contract a selling wallet belongs to, and it decides the registration

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -393,16 +393,17 @@ async def list_wallets(
         async with HTTPXClient() as client:
             payment_sources = await _list_payment_sources(
                 client, masumi, headers, require_complete, report)
-            if report is not None:
-                report.source_count = len(payment_sources)
-                report.networks = sorted(
-                    {source.get("network") for source in payment_sources
-                     if source.get("network")})
             sources = [
                 source for source in payment_sources
                 if not source.get("network")
                 or source.get("network") == masumi.registry_network
             ]
+            if report is not None:
+                report.source_count = len(payment_sources)
+                report.matched_count = len(sources)
+                report.networks = sorted(
+                    {source.get("network") for source in payment_sources
+                     if source.get("network")})
             missing = [index for index, source in enumerate(sources)
                        if not source.get("SellingWallets")]
             semaphore = asyncio.Semaphore(
@@ -430,6 +431,10 @@ async def list_wallets(
                         raise RuntimeError(
                             "Could not load the complete selling wallet "
                             "inventory") from result
+                    record_problem(
+                        report,
+                        f"GET /wallet for payment source "
+                        f"{sources[index].get('id', '')} failed: {result}")
                     logger.warning(
                         "Failed to list wallets of payment source %s: %s",
                         sources[index].get("id", ""), result)

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -25,6 +25,7 @@ from kodosumi.service.expose.pricing import (  # noqa: F401
     PAYMENT_SOURCE_TYPE_V2, pricing_to_yaml_format,
     pricing_yaml_to_registry, registry_pricing_to_supported_sources)
 from kodosumi.service.expose.wallet_inventory import (WalletReport,
+                                                      describe_exception,
                                                       record_problem)
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,12 @@ async def _list_source_selling_wallets(
     that come back without them.
     """
     if not source_id:
+        # No id means no way to ask for this source's wallets, so its
+        # wallets are missing from the answer rather than absent.
+        record_problem(
+            report,
+            "a payment source arrived without an id, so its selling "
+            "wallets could not be read")
         return []
     wallets: List[Dict] = []
     seen_ids = set()
@@ -150,7 +157,9 @@ async def _list_payment_sources(
                     "Could not load the complete payment source list"
                 ) from error
             record_problem(
-                report, f"GET /payment-source failed: {error}")
+                report,
+                f"GET /payment-source failed: "
+                f"{describe_exception(error)}")
             logger.warning(
                 "Stopped listing payment sources after %s entries: %s",
                 len(sources), error,
@@ -265,7 +274,8 @@ async def list_wallets(
                     record_problem(
                         report,
                         f"GET /wallet for payment source "
-                        f"{sources[index].get('id', '')} failed: {result}")
+                        f"{sources[index].get('id', '')} failed: "
+                        f"{describe_exception(result)}")
                     logger.warning(
                         "Failed to list wallets of payment source %s: %s",
                         sources[index].get("id", ""), result)
@@ -293,7 +303,8 @@ async def list_wallets(
         logger.error("Error listing wallets: %s", e)
         if require_complete:
             raise
-        record_problem(report, str(e))
+        record_problem(
+            report, f"listing the wallets failed: {describe_exception(e)}")
         return []
 
 

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -18,31 +18,17 @@ from kodosumi.service.expose.currency import (CURRENCY_DECIMALS,  # noqa: F401
                                               base_to_human_amount,
                                               human_to_base_amount,
                                               unit_to_currency)
+from kodosumi.service.expose.pricing import (  # noqa: F401
+    DEFAULT_SUPPORTED_PAYMENT_SOURCE_INDEX, MAX_ATOMIC_AMOUNT,
+    MAX_ATOMIC_AMOUNT_DIGITS, MAX_FIXED_PRICING_ENTRIES,
+    MIN_FIXED_PRICING_ENTRIES, PAYMENT_SOURCE_TYPE_V1,
+    PAYMENT_SOURCE_TYPE_V2, pricing_to_yaml_format,
+    pricing_yaml_to_registry, registry_pricing_to_supported_sources)
 from kodosumi.service.expose.wallet_inventory import (WalletReport,
                                                       record_problem)
 
 logger = logging.getLogger(__name__)
 
-# Masumi payment source types. A payment source is the deployed escrow
-# contract a selling wallet belongs to, and it decides the registration
-# shape: V1 entries carry top-level AgentPricing, V2 entries carry a
-# supportedPaymentSources list that prices every source on its own.
-PAYMENT_SOURCE_TYPE_V1 = "Web3CardanoV1"
-PAYMENT_SOURCE_TYPE_V2 = "Web3CardanoV2"
-
-# Index into supportedPaymentSources that Kodosumi registers and pays with.
-# Kodosumi advertises exactly one source per agent, so the index is always 0.
-DEFAULT_SUPPORTED_PAYMENT_SOURCE_INDEX = 0
-
-# Bounds the payment node enforces on a V2 registration. Checking them here
-# turns an opaque 400 from the node into a message that names the flow YAML
-# field the operator has to correct.
-MIN_FIXED_PRICING_ENTRIES = 1
-MAX_FIXED_PRICING_ENTRIES = 5
-# The node bounds the amount string at 19 characters and parses it into a
-# Postgres bigint, so leading zeros count and the value has a ceiling.
-MAX_ATOMIC_AMOUNT_DIGITS = 19
-MAX_ATOMIC_AMOUNT = 9223372036854775807
 
 # Page size of the /wallet endpoint. The node caps `take` at 100 and its
 # cursor is inclusive, so a page repeats the row the cursor names.
@@ -52,180 +38,6 @@ MAX_CONCURRENT_WALLET_REQUESTS = 20
 PAYMENT_SOURCE_PAGE_SIZE = 100
 MAX_PAYMENT_SOURCE_PAGES = 50
 
-
-def pricing_yaml_to_registry(pricing_yaml: Any, network: str) -> Dict:
-    """
-    Convert Kodosumi YAML pricing format to Masumi Registry API format.
-
-    YAML format:
-        agentPricing:
-          - pricingType: Fixed
-            fixedPricing:
-              - amount: "10000"
-                unit: "16a55b2a..."
-
-    Registry format:
-        {"pricingType": "Fixed", "Pricing": [{"amount": "10000", "unit": "16a55b2a..."}]}
-
-    Raises ValueError when the YAML is not one of the shapes above. The
-    metadata is hand edited, so a mapping or a scalar reaches this function
-    and must become a message the operator can act on, not a KeyError.
-    """
-    if not pricing_yaml:
-        return {"pricingType": "Free"}
-
-    # A single mapping is the shape operators write most often by mistake.
-    if isinstance(pricing_yaml, dict):
-        pricing_yaml = [pricing_yaml]
-    if not isinstance(pricing_yaml, list) or not isinstance(
-            pricing_yaml[0], dict):
-        raise ValueError(
-            "agentPricing must be a list of pricing entries, for example: "
-            "agentPricing:\n  - pricingType: Free"
-        )
-
-    first = pricing_yaml[0]
-    pricing_type = first.get("pricingType", "Free")
-
-    if pricing_type == "Free":
-        return {"pricingType": "Free"}
-
-    fixed_pricing = first.get("fixedPricing") or []
-    if not isinstance(fixed_pricing, list):
-        raise ValueError(
-            "agentPricing[0].fixedPricing must be a list of "
-            "{amount, unit} entries")
-    registry_pricing = []
-    for p in fixed_pricing:
-        if not isinstance(p, dict):
-            raise ValueError(
-                "Every agentPricing[0].fixedPricing entry must be a mapping "
-                "with an amount and a unit")
-        unit = p.get("unit", "")
-        # Convert "lovelace" to empty string for registry
-        if unit == "lovelace":
-            unit = ""
-        registry_pricing.append({
-            "amount": str(p.get("amount", "0")),
-            "unit": unit,
-        })
-
-    return {
-        "pricingType": "Fixed",
-        "Pricing": registry_pricing,
-    }
-
-
-def pricing_to_yaml_format(pricing_type: str, amount: float, currency: str, network: str) -> List[Dict]:
-    """
-    Convert UI pricing input to Kodosumi YAML format.
-
-    Returns list suitable for agentPricing in meta YAML.
-    """
-    if pricing_type == "Free":
-        return [{"pricingType": "Free"}]
-
-    unit_hex = CURRENCY_UNITS.get(currency, {}).get(network, "")
-    base_amount = human_to_base_amount(amount)
-
-    return [{
-        "pricingType": "Fixed",
-        "fixedPricing": [{
-            "amount": base_amount,
-            "unit": unit_hex,
-        }],
-    }]
-
-
-def _atomic_amount(amount: Any) -> str:
-    """
-    Render one price as the atomic amount string the payment node accepts.
-
-    The node takes digits only, at most 19 characters of them, and rejects
-    zero. A missing amount used to default to "0" and was refused on chain
-    with an error that never named the flow YAML.
-
-    The result is normalised, so leading zeros written in the YAML cannot
-    push an otherwise valid amount past the node's 19 character bound.
-    """
-    text = str(amount if amount is not None else "").strip()
-    if not text.isdigit() or int(text) <= 0:
-        raise ValueError(
-            f"Pricing amount must be a positive whole number of base units, "
-            f"got '{amount}'."
-        )
-    value = int(text)
-    if value > MAX_ATOMIC_AMOUNT:
-        raise ValueError(
-            f"Pricing amount is above the largest amount the payment node "
-            f"stores ({MAX_ATOMIC_AMOUNT}): '{amount}'."
-        )
-    normalised = str(value)
-    if len(normalised) > MAX_ATOMIC_AMOUNT_DIGITS:
-        raise ValueError(
-            f"Pricing amount has more than {MAX_ATOMIC_AMOUNT_DIGITS} digits: "
-            f"'{amount}'."
-        )
-    return normalised
-
-
-def registry_pricing_to_supported_sources(
-    registry_pricing: Dict,
-    network: str,
-    smart_contract_address: str,
-) -> List[Dict]:
-    """
-    Convert V1 registry pricing into the V2 supportedPaymentSources list.
-
-    V2 registrations reject the top-level AgentPricing field. Each entry in
-    supportedPaymentSources names one escrow contract and owns its price.
-    Kodosumi advertises the single contract the selling wallet belongs to.
-
-    Registry format (V1):
-        {"pricingType": "Fixed", "Pricing": [{"amount": "10000", "unit": ""}]}
-
-    Supported source format (V2):
-        [{"chain": "Cardano", "network": "Preprod",
-          "paymentSourceType": "Web3CardanoV2", "address": "addr_test1...",
-          "pricing": {"pricingType": "Fixed",
-                      "fixed": [{"asset": "", "amount": "10000"}]}}]
-    """
-    if not smart_contract_address:
-        raise ValueError(
-            "V2 registration requires the smart contract address of the "
-            "selling wallet payment source"
-        )
-
-    pricing_type = registry_pricing.get("pricingType", "Free")
-    if pricing_type == "Fixed":
-        pricing: Dict[str, Any] = {
-            "pricingType": "Fixed",
-            "fixed": [
-                {
-                    "asset": price.get("unit", ""),
-                    "amount": _atomic_amount(price.get("amount")),
-                }
-                for price in registry_pricing.get("Pricing") or []
-            ],
-        }
-        entry_count = len(pricing["fixed"])
-        if not (MIN_FIXED_PRICING_ENTRIES <= entry_count
-                <= MAX_FIXED_PRICING_ENTRIES):
-            raise ValueError(
-                f"Fixed pricing needs between {MIN_FIXED_PRICING_ENTRIES} and "
-                f"{MAX_FIXED_PRICING_ENTRIES} priced assets, got "
-                f"{entry_count}. Add fixedPricing entries to agentPricing."
-            )
-    else:
-        pricing = {"pricingType": pricing_type}
-
-    return [{
-        "chain": "Cardano",
-        "network": network,
-        "paymentSourceType": PAYMENT_SOURCE_TYPE_V2,
-        "address": smart_contract_address,
-        "pricing": pricing,
-    }]
 
 
 async def _list_source_selling_wallets(

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -13,25 +13,15 @@ import yaml
 
 from kodosumi.config import MasumiConfig
 from kodosumi.helper import HTTPXClient
+from kodosumi.service.expose.currency import (CURRENCY_DECIMALS,  # noqa: F401
+                                              CURRENCY_UNITS,
+                                              base_to_human_amount,
+                                              human_to_base_amount,
+                                              unit_to_currency)
 from kodosumi.service.expose.wallet_inventory import (WalletReport,
                                                       record_problem)
 
 logger = logging.getLogger(__name__)
-
-# Currency mapping: human-readable → hex unit on-chain
-CURRENCY_UNITS = {
-    "USDM": {
-        "Preprod": "16a55b2a349361ff88c03788f93e1e966e5d689605d044fef722ddde0014df10745553444d",
-        "Mainnet": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d",
-    },
-    "ADA": {
-        "Preprod": "",
-        "Mainnet": "",
-    },
-}
-
-# All currencies have 6 decimal places
-CURRENCY_DECIMALS = 6
 
 # Masumi payment source types. A payment source is the deployed escrow
 # contract a selling wallet belongs to, and it decides the registration
@@ -61,26 +51,6 @@ MAX_WALLET_PAGES = 50
 MAX_CONCURRENT_WALLET_REQUESTS = 20
 PAYMENT_SOURCE_PAGE_SIZE = 100
 MAX_PAYMENT_SOURCE_PAGES = 50
-
-
-def human_to_base_amount(amount: float) -> str:
-    """Convert human-readable amount (e.g. 0.01) to base units string (e.g. '10000')."""
-    base = round(amount * (10 ** CURRENCY_DECIMALS))
-    return str(base)
-
-
-def base_to_human_amount(base_amount: str) -> float:
-    """Convert base units string (e.g. '10000') to human-readable amount (e.g. 0.01)."""
-    return int(base_amount) / (10 ** CURRENCY_DECIMALS)
-
-
-def unit_to_currency(unit: str) -> str:
-    """Map hex unit string back to human-readable currency name."""
-    for currency, networks in CURRENCY_UNITS.items():
-        for network, hex_unit in networks.items():
-            if hex_unit == unit:
-                return currency
-    return "ADA" if unit == "" else "unknown"
 
 
 def pricing_yaml_to_registry(pricing_yaml: Any, network: str) -> Dict:

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -13,6 +13,8 @@ import yaml
 
 from kodosumi.config import MasumiConfig
 from kodosumi.helper import HTTPXClient
+from kodosumi.service.expose.wallet_inventory import (WalletReport,
+                                                      record_problem)
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +264,7 @@ async def _list_source_selling_wallets(
     headers: Dict,
     source_id: str,
     require_complete: bool = False,
+    report: Optional[WalletReport] = None,
 ) -> List[Dict]:
     """
     Read selling wallets of one payment source from the /wallet endpoint.
@@ -289,6 +292,10 @@ async def _list_source_selling_wallets(
                 raise RuntimeError(
                     f"Could not list every wallet of payment source "
                     f"{source_id}: HTTP {resp.status_code}")
+            record_problem(
+                report,
+                f"GET /wallet for payment source {source_id} answered "
+                f"HTTP {resp.status_code}")
             logger.warning(
                 "Failed to list wallets of payment source %s: %s",
                 source_id, resp.text,
@@ -328,6 +335,7 @@ async def _list_payment_sources(
     masumi: MasumiConfig,
     headers: dict,
     require_complete: bool = False,
+    report: Optional[WalletReport] = None,
 ) -> List[Dict]:
     """List all payment sources across the node's inclusive cursor."""
     sources: List[Dict] = []
@@ -348,6 +356,8 @@ async def _list_payment_sources(
                 raise RuntimeError(
                     "Could not load the complete payment source list"
                 ) from error
+            record_problem(
+                report, f"GET /payment-source failed: {error}")
             logger.warning(
                 "Stopped listing payment sources after %s entries: %s",
                 len(sources), error,
@@ -358,6 +368,9 @@ async def _list_payment_sources(
                 raise RuntimeError(
                     "Could not load the complete payment source list: "
                     f"HTTP {resp.status_code}")
+            record_problem(
+                report,
+                f"GET /payment-source answered HTTP {resp.status_code}")
             logger.warning("Failed to list payment sources: %s", resp.text)
             return sources
         page = resp.json().get("data", {}).get("PaymentSources", [])
@@ -387,7 +400,9 @@ async def _list_payment_sources(
 
 
 async def list_wallets(
-    masumi: MasumiConfig, require_complete: bool = False
+    masumi: MasumiConfig,
+    require_complete: bool = False,
+    report: Optional[WalletReport] = None,
 ) -> List[Dict]:
     """
     List selling wallets from Masumi Payment API.
@@ -396,13 +411,23 @@ async def list_wallets(
     Each entry carries the paymentSourceType and smartContractAddress of
     its payment source, because the wallet selects the registration
     version: a Web3CardanoV2 wallet registers a V2 agent.
+
+    Pass a report to learn why an empty list is empty. The node answers a
+    token that may not read this network with a normal empty 200, so the
+    result on its own cannot tell a missing wallet from a missing
+    permission.
     """
     headers = {"accept": "application/json", "token": masumi.token}
 
     try:
         async with HTTPXClient() as client:
             payment_sources = await _list_payment_sources(
-                client, masumi, headers, require_complete)
+                client, masumi, headers, require_complete, report)
+            if report is not None:
+                report.source_count = len(payment_sources)
+                report.networks = sorted(
+                    {source.get("network") for source in payment_sources
+                     if source.get("network")})
             sources = [
                 source for source in payment_sources
                 if not source.get("network")
@@ -421,6 +446,7 @@ async def list_wallets(
                         headers,
                         sources[index].get("id", ""),
                         require_complete,
+                        report,
                     )
 
             results = await asyncio.gather(
@@ -461,6 +487,7 @@ async def list_wallets(
         logger.error("Error listing wallets: %s", e)
         if require_complete:
             raise
+        record_problem(report, str(e))
         return []
 
 

--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -288,11 +288,22 @@ async def _list_source_selling_wallets(
                 raise RuntimeError(
                     f"Could not completely paginate wallets of payment "
                     f"source {source_id}")
+            # The list stops here and is not the whole list, so a wallet
+            # can be missing from it. Say so, or the caller reads the
+            # absence as proof that no such wallet exists.
+            record_problem(
+                report,
+                f"the wallet list of payment source {source_id} could not "
+                f"be paged past {len(wallets)} row(s)")
             return wallets
     if require_complete:
         raise RuntimeError(
             f"Could not completely paginate wallets of payment source "
             f"{source_id} within {MAX_WALLET_PAGES} pages")
+    record_problem(
+        report,
+        f"listing the wallets of payment source {source_id} stopped after "
+        f"{MAX_WALLET_PAGES} pages")
     logger.warning(
         "Stopped listing wallets of payment source %s after %s pages",
         source_id, MAX_WALLET_PAGES,
@@ -357,11 +368,19 @@ async def _list_payment_sources(
             if require_complete:
                 raise RuntimeError(
                     "Could not completely paginate payment sources")
+            record_problem(
+                report,
+                f"the payment source list could not be paged past "
+                f"{len(sources)} row(s)")
             return sources
     if require_complete:
         raise RuntimeError(
             "Could not load the complete payment source list within "
             f"{MAX_PAYMENT_SOURCE_PAGES} pages")
+    record_problem(
+        report,
+        f"listing the payment sources stopped after "
+        f"{MAX_PAYMENT_SOURCE_PAGES} pages")
     logger.warning(
         "Stopped listing payment sources after %s pages",
         MAX_PAYMENT_SOURCE_PAGES,

--- a/kodosumi/service/expose/wallet_control.py
+++ b/kodosumi/service/expose/wallet_control.py
@@ -6,6 +6,7 @@ from litestar.datastructures import State
 from litestar.exceptions import NotFoundException
 
 from kodosumi.service.expose import db
+from kodosumi.service.expose.wallet_inventory import WalletReport
 from kodosumi.service.jwt import operator_guard
 
 
@@ -39,8 +40,9 @@ class WalletsControl(litestar.Controller):
             return {"wallets": [], "error": str(e)}
 
         from kodosumi.service.expose.registry import list_wallets
+        report = WalletReport()
         try:
-            wallets = await list_wallets(masumi)
+            wallets = await list_wallets(masumi, report=report)
         except Exception as e:
             return {
                 "wallets": [],
@@ -49,10 +51,12 @@ class WalletsControl(litestar.Controller):
             }
 
         if not wallets:
+            # The node answers a token that may not read this network with a
+            # normal empty 200, so the empty list alone cannot name its own
+            # cause. The report carries what the token could see.
             return {
                 "wallets": [],
-                "error": f"No selling wallets found for network '{network}'. "
-                         "Check your Masumi Payment API token and configuration.",
+                "error": report.describe_empty(network),
             }
 
         return {"wallets": wallets, "network": network}

--- a/kodosumi/service/expose/wallet_control.py
+++ b/kodosumi/service/expose/wallet_control.py
@@ -53,10 +53,20 @@ class WalletsControl(litestar.Controller):
         if not wallets:
             # The node answers a token that may not read this network with a
             # normal empty 200, so the empty list alone cannot name its own
-            # cause. The report carries what the token could see.
+            # cause. The report carries what the token could see. It is
+            # compared against the node's own network name, never against
+            # the name of the KODO_MASUMI entry the operator chose.
             return {
                 "wallets": [],
-                "error": report.describe_empty(network),
+                "error": report.describe_empty(masumi.registry_network),
             }
 
-        return {"wallets": wallets, "network": network}
+        # A list can be non-empty and still be missing the one wallet the
+        # operator is looking for, when a payment source could not be read.
+        # Saying so is what stops the migrate dialog from reporting a
+        # transient failure as a missing Web3CardanoV2 wallet.
+        warning = report.describe_partial()
+        result = {"wallets": wallets, "network": network}
+        if warning:
+            result["warning"] = warning
+        return result

--- a/kodosumi/service/expose/wallet_inventory.py
+++ b/kodosumi/service/expose/wallet_inventory.py
@@ -1,0 +1,63 @@
+"""Evidence for an empty selling wallet list.
+
+The payment node reports most causes of an empty list as a normal 200
+answer with no rows: an API key that is limited to another network, a node
+that holds no payment source for this network, or a payment source that has
+no selling wallet yet. The panel used to collapse every one of them into
+"No selling wallets found for network X. Check your Masumi Payment API
+token and configuration", which sends the operator looking for a wallet
+that was never the problem.
+
+This module keeps what the token could see next to what was asked for, so
+the message can name the cause instead of guessing at it.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class WalletReport:
+    """What one wallet listing saw while it ran.
+
+    source_count and networks describe every payment source the token could
+    read, before the network of the expose narrowed them down. problems
+    holds the requests that did not answer, and stays empty on a clean run.
+    """
+
+    source_count: int = 0
+    networks: List[str] = field(default_factory=list)
+    problems: List[str] = field(default_factory=list)
+
+    def describe_empty(self, network: str) -> str:
+        """Say why a wallet listing came back empty for one network."""
+        if self.problems:
+            return (
+                f"The Masumi node did not answer every request for network "
+                f"'{network}': {self.problems[0]}"
+            )
+        if not self.source_count:
+            return (
+                f"The Masumi API token sees no payment source at all. Either "
+                f"it is limited to a network other than '{network}', or "
+                f"KODO_MASUMI points at a different node than the one that "
+                f"holds your payment sources."
+            )
+        if network not in self.networks:
+            seen = ", ".join(self.networks) or "none"
+            return (
+                f"The Masumi API token sees {self.source_count} payment "
+                f"source(s), on {seen}, and none on '{network}'. Either the "
+                f"network limit of the token excludes '{network}', or "
+                f"KODO_MASUMI points at a different node."
+            )
+        return (
+            f"No payment source on '{network}' has a selling wallet yet. "
+            f"Add one in the Masumi payment service, then reload this page."
+        )
+
+
+def record_problem(report: Optional[WalletReport], message: str) -> None:
+    """Note a request that did not answer, when a report is being kept."""
+    if report is not None:
+        report.problems.append(message)

--- a/kodosumi/service/expose/wallet_inventory.py
+++ b/kodosumi/service/expose/wallet_inventory.py
@@ -1,4 +1,4 @@
-"""Evidence for an empty selling wallet list.
+"""Evidence for an empty or partial selling wallet list.
 
 The payment node reports most causes of an empty list as a normal 200
 answer with no rows: an API key that is limited to another network, a node
@@ -9,7 +9,9 @@ token and configuration", which sends the operator looking for a wallet
 that was never the problem.
 
 This module keeps what the token could see next to what was asked for, so
-the message can name the cause instead of guessing at it.
+the message can name the cause instead of guessing at it. A list that is
+only partly loaded gets its own sentence: a wallet may be missing from it
+because one request failed, not because it does not exist.
 """
 
 from dataclasses import dataclass, field
@@ -21,39 +23,61 @@ class WalletReport:
     """What one wallet listing saw while it ran.
 
     source_count and networks describe every payment source the token could
-    read, before the network of the expose narrowed them down. problems
-    holds the requests that did not answer, and stays empty on a clean run.
+    read. matched_count is how many of them survived the network filter and
+    were actually asked for wallets, which is what separates "no source on
+    this network" from "a source with no wallet". problems holds the
+    requests that did not answer, and stays empty on a clean run.
+
+    The network names here come from the payment node, so compare them
+    against MasumiConfig.registry_network, never against the name of a
+    KODO_MASUMI entry.
     """
 
     source_count: int = 0
+    matched_count: int = 0
     networks: List[str] = field(default_factory=list)
     problems: List[str] = field(default_factory=list)
 
-    def describe_empty(self, network: str) -> str:
+    def describe_empty(self, registry_network: str) -> str:
         """Say why a wallet listing came back empty for one network."""
         if self.problems:
             return (
                 f"The Masumi node did not answer every request for network "
-                f"'{network}': {self.problems[0]}"
+                f"'{registry_network}': {self.problems[0]}"
             )
         if not self.source_count:
             return (
                 f"The Masumi API token sees no payment source at all. Either "
-                f"it is limited to a network other than '{network}', or "
-                f"KODO_MASUMI points at a different node than the one that "
+                f"it is limited to a network other than '{registry_network}', "
+                f"or KODO_MASUMI points at a different node than the one that "
                 f"holds your payment sources."
             )
-        if network not in self.networks:
+        if not self.matched_count:
             seen = ", ".join(self.networks) or "none"
             return (
                 f"The Masumi API token sees {self.source_count} payment "
-                f"source(s), on {seen}, and none on '{network}'. Either the "
-                f"network limit of the token excludes '{network}', or "
-                f"KODO_MASUMI points at a different node."
+                f"source(s), on {seen}, and none on '{registry_network}'. "
+                f"Either the network limit of the token excludes "
+                f"'{registry_network}', or KODO_MASUMI points at a different "
+                f"node."
             )
         return (
-            f"No payment source on '{network}' has a selling wallet yet. "
-            f"Add one in the Masumi payment service, then reload this page."
+            f"No payment source on '{registry_network}' has a selling wallet "
+            f"yet. Add one in the Masumi payment service, then reload this "
+            f"page."
+        )
+
+    def describe_partial(self) -> Optional[str]:
+        """Warn that a non-empty list may still be missing wallets.
+
+        A wallet that is absent because its payment source could not be
+        read looks exactly like a wallet that does not exist, so a list
+        with a failed request behind it cannot be treated as complete.
+        """
+        if not self.problems:
+            return None
+        return (
+            f"This wallet list may be incomplete: {self.problems[0]}"
         )
 
 

--- a/kodosumi/service/expose/wallet_inventory.py
+++ b/kodosumi/service/expose/wallet_inventory.py
@@ -81,6 +81,20 @@ class WalletReport:
         )
 
 
+def describe_exception(error: BaseException) -> str:
+    """Name an exception that stringifies to nothing.
+
+    Every httpx timeout carries an empty message, so "failed: " reached
+    the operator with nothing after the colon. A problem that names no
+    cause is the state this evidence exists to replace, and the class
+    name is the least that always says something.
+    """
+    text = str(error).strip()
+    if not text:
+        return type(error).__name__
+    return f"{type(error).__name__}: {text}"
+
+
 def record_problem(report: Optional[WalletReport], message: str) -> None:
     """Note a request that did not answer, when a report is being kept."""
     if report is not None:

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -1,0 +1,263 @@
+// Drive the real openMigrateDialog against the real loadWallets, with a
+// stub fetch standing in for the wallets endpoint.
+//
+// The dialog used to say "No Web3CardanoV2 selling wallet on this network"
+// for every empty list, including lists that failed to load, and it read
+// the copy of the list taken at page load. Each case below pins one of the
+// answers a node can give to the sentence the operator should see.
+//
+// Run it with: node tests/test_migrate_dialog.js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const walletsSource = fs.readFileSync(
+    'kodosumi/service/admin/templates/expose/_registry_wallets_script.html',
+    'utf8');
+const dialogSource = fs.readFileSync(
+    'kodosumi/service/admin/templates/expose/_registry_dialog_script.html',
+    'utf8');
+
+const start = dialogSource.indexOf('let migrateDialogGeneration = 0;');
+assert.notEqual(start, -1);
+const end = dialogSource.indexOf('\nasync function submitMigration(', start);
+assert.ok(end > start);
+const openSource = dialogSource.slice(start, end);
+
+function makeElement(extra) {
+    return Object.assign({
+        value: '',
+        textContent: '',
+        innerHTML: '',
+        checked: false,
+        disabled: false,
+        style: {},
+        children: [],
+        appendChild(child) { this.children.push(child); },
+        showModal() { this.shown = true; },
+    }, extra || {});
+}
+
+async function open(responder) {
+    const elements = {
+        mig_current_agent: makeElement(),
+        mig_pricing: makeElement(),
+        mig_wallet: makeElement(),
+        mig_submit: makeElement(),
+        mig_error: makeElement(),
+        mig_deregister: makeElement(),
+        mig_api_base_url: makeElement(),
+        'migrate-dialog': makeElement(),
+    };
+    const infoLines = [];
+    let fetchCount = 0;
+
+    const context = {
+        console,
+        exposeName: 'meme-copy',
+        activeDialogIdx: null,
+        hideRegError() {},
+        jsyaml: {load: () => ({agentIdentifier: 'ad6424e3…1855',
+                               agentPricing: [{pricingType: 'Fixed',
+                                               fixedPricing: [{amount: '900000',
+                                                               unit: 'usdm'}]}]})},
+        fetch: async () => { fetchCount += 1; return responder(); },
+        document: {
+            querySelector: () => ({value: 'display: Meme Copy'}),
+            querySelectorAll: (selector) => {
+                if (selector === '.registry-section') {
+                    return [{id: 'registry_0'}];
+                }
+                return [];
+            },
+            getElementById: (id) => {
+                if (id === 'reg_info_0') {
+                    const info = makeElement();
+                    infoLines.push(info);
+                    return info;
+                }
+                return elements[id] || null;
+            },
+            createElement: () => makeElement(),
+        },
+    };
+    vm.createContext(context);
+    vm.runInContext(walletsSource + '\n' + openSource, context);
+    await context.openMigrateDialog(0);
+    return {elements, context, fetchCount, infoLines};
+}
+
+function jsonResponse(payload) {
+    return {ok: true, status: 200, json: async () => payload};
+}
+
+(async () => {
+    // 1. The node answered, and it said why the list is empty.
+    let run = await open(() => jsonResponse({
+        wallets: [],
+        error: "The Masumi API token sees 1 payment source(s), on Preprod, " +
+               "and none on 'Mainnet'. Either the network limit of the token " +
+               "excludes 'Mainnet', or KODO_MASUMI points at a different node.",
+    }));
+    console.log('\n1. node reports a reason');
+    console.log('   dialog :', run.elements.mig_error.textContent);
+    console.log('   submit disabled:', run.elements.mig_submit.disabled);
+    assert.match(run.elements.mig_error.textContent, /Preprod/);
+    assert.equal(run.elements.mig_submit.disabled, true);
+
+    // 2. Wallets loaded, and every one of them is V1.
+    run = await open(() => jsonResponse({wallets: [
+        {walletVkey: 'vkey-v1-aaaaaa', walletAddress: 'addr1',
+         note: 'seller', paymentSourceType: 'Web3CardanoV1'},
+    ]}));
+    console.log('\n2. wallets load, all V1');
+    console.log('   dialog :', run.elements.mig_error.textContent);
+    console.log('   submit disabled:', run.elements.mig_submit.disabled);
+    assert.equal(
+        run.elements.mig_error.textContent,
+        'No Web3CardanoV2 selling wallet on this network. ' +
+        'Add one in the Masumi payment service first.');
+    assert.equal(run.elements.mig_submit.disabled, true);
+
+    // 3. A V2 wallet exists. It must be offered, and the list must be read
+    //    while the dialog opens, not taken from the page load.
+    run = await open(() => jsonResponse({wallets: [
+        {walletVkey: 'vkey-v2-bbbbbb', walletAddress: 'addr2',
+         note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'},
+        {walletVkey: 'vkey-v1-aaaaaa', walletAddress: 'addr1',
+         note: 'seller', paymentSourceType: 'Web3CardanoV1'},
+    ]}));
+    console.log('\n3. a V2 wallet exists');
+    console.log('   fetches during open:', run.fetchCount);
+    console.log('   options:',
+                run.elements.mig_wallet.children.map((o) => o.textContent));
+    console.log('   submit disabled:', run.elements.mig_submit.disabled);
+    assert.equal(run.fetchCount, 1);
+    assert.equal(run.elements.mig_wallet.children.length, 1);
+    assert.equal(run.elements.mig_wallet.children[0].textContent,
+                 'v2 seller [V2]');
+    assert.equal(run.elements.mig_submit.disabled, false);
+    assert.equal(run.elements.mig_error.style.display, 'none');
+
+    // 4. The endpoint itself failed. The dialog must not claim a missing
+    //    V2 wallet on the strength of a list that never arrived.
+    run = await open(() => ({ok: false, status: 502, json: async () => ({})}));
+    console.log('\n4. wallets endpoint fails');
+    console.log('   dialog :', run.elements.mig_error.textContent);
+    assert.match(run.elements.mig_error.textContent, /HTTP 502/);
+    assert.doesNotMatch(run.elements.mig_error.textContent, /Add one in the/);
+
+    // 5. The url override starts empty on every open.
+    console.log('\n5. url override default:',
+                JSON.stringify(run.elements.mig_api_base_url.value));
+    assert.equal(run.elements.mig_api_base_url.value, '');
+
+    // 6. Reopen the same flow while the first load is still in flight.
+    //    The late one must not append a second copy of the options.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        const v2 = {wallets: [{walletVkey: 'vkey-v2-bbbbbb',
+                               walletAddress: 'addr2', note: 'v2 seller',
+                               paymentSourceType: 'Web3CardanoV2'}]};
+        let release;
+        const gate = new Promise((r) => { release = r; });
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) { await gate; }
+                return jsonResponse(v2);
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        const first = context.openMigrateDialog(0);
+        context.activeDialogIdx = null;          // Escape closes the dialog
+        const second = context.openMigrateDialog(0);
+        await second;
+        release();
+        await first;
+        console.log('\n6. reopened while the first load was in flight');
+        console.log('   options:',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        assert.equal(elements.mig_wallet.children.length, 1);
+    }
+
+    // 7. A list that loaded but is short one payment source. The dialog
+    //    works, so the caution must not be painted as a refusal.
+    run = await open(() => jsonResponse({
+        wallets: [{walletVkey: 'vkey-v2-bbbbbb', walletAddress: 'addr2',
+                   note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'}],
+        warning: 'This wallet list may be incomplete: GET /wallet for ' +
+                 'payment source src-v1 answered HTTP 503',
+    }));
+    console.log('\n7. partial list, V2 wallet present');
+    console.log('   dialog :', run.elements.mig_error.textContent);
+    console.log('   colour :', run.elements.mig_error.style.color);
+    console.log('   submit disabled:', run.elements.mig_submit.disabled);
+    assert.match(run.elements.mig_error.textContent, /may be incomplete/);
+    assert.equal(run.elements.mig_error.style.color,
+                 'var(--on-surface-variant)');
+    assert.equal(run.elements.mig_submit.disabled, false);
+
+    // 8. The operator closes the dialog while the quiet load is running and
+    //    the load then fails. The reason must reach the page instead of
+    //    disappearing with the dialog.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        const info = makeElement();
+        let release;
+        const gate = new Promise((r) => { release = r; });
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                await gate;
+                return {ok: false, status: 500, json: async () => ({})};
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? info : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        const pending = context.openMigrateDialog(0);
+        context.activeDialogIdx = null;      // Escape closes the dialog
+        release();
+        await pending;
+        console.log('\n8. dialog closed while the quiet load failed');
+        console.log('   page   :', info.textContent);
+        assert.match(info.textContent, /HTTP 500/);
+    }
+
+    console.log('\nall eight dialog cases behaved as expected');
+})();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -34,7 +34,8 @@ function makeElement(extra) {
         style: {},
         children: [],
         appendChild(child) { this.children.push(child); },
-        showModal() { this.shown = true; },
+        showModal() { this.shown = true; this.open = true; },
+        close() { this.open = false; },
     }, extra || {});
 }
 
@@ -280,5 +281,52 @@ function jsonResponse(payload) {
         assert.deepEqual(offenders, []);
     }
 
-    console.log('\nall nine dialog cases behaved as expected');
+    // 10. The operator presses Escape and then opens the register dialog
+    //     on the same section. activeDialogIdx belongs to both dialogs, so
+    //     it points at this section again while the migrate dialog is
+    //     shut. The reason must still reach the page, not the hidden
+    //     migrate error line.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        const info = makeElement();
+        let release;
+        const gate = new Promise((r) => { release = r; });
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                await gate;
+                return {ok: false, status: 503, json: async () => ({})};
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? info : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        const pending = context.openMigrateDialog(0);
+        elements['migrate-dialog'].close();   // Escape shuts the dialog
+        context.activeDialogIdx = 0;          // the register dialog claims it
+        release();
+        await pending;
+        console.log('\n10. register dialog opened on the same section');
+        console.log('   page   :', info.textContent);
+        console.log('   hidden :', elements.mig_error.textContent);
+        assert.match(info.textContent, /HTTP 503/);
+        assert.equal(elements.mig_error.textContent, '');
+    }
+
+    console.log('\nall ten dialog cases behaved as expected');
 })();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -20,7 +20,10 @@ const dialogSource = fs.readFileSync(
 
 const start = dialogSource.indexOf('let migrateDialogGeneration = 0;');
 assert.notEqual(start, -1);
-const end = dialogSource.indexOf('\nasync function submitMigration(', start);
+// Take openMigrateDialog and submitMigration together: the dialog
+// writes the api_base_url field and the submit reads it, and a test
+// that loads only the first half cannot see the field leave the page.
+const end = dialogSource.indexOf('\nasync function deregisterPrevious(', start);
 assert.ok(end > start);
 const openSource = dialogSource.slice(start, end);
 
@@ -148,10 +151,44 @@ function jsonResponse(payload) {
     assert.match(run.elements.mig_error.textContent, /HTTP 502/);
     assert.doesNotMatch(run.elements.mig_error.textContent, /Add one in the/);
 
-    // 5. The url override starts empty on every open.
-    console.log('\n5. url override default:',
-                JSON.stringify(run.elements.mig_api_base_url.value));
-    assert.equal(run.elements.mig_api_base_url.value, '');
+    // 5. The url override starts empty on every open. A fresh element is
+    //    empty anyway, so type into it and reopen: only a real reset can
+    //    clear it. A url left over from an abandoned dialog would be
+    //    minted on chain by the next migration.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => jsonResponse({wallets: []}),
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        await context.openMigrateDialog(0);
+        elements.mig_api_base_url.value = 'https://stale.example/sumi/old';
+        elements.mig_deregister.checked = true;
+        context.activeDialogIdx = null;
+        await context.openMigrateDialog(0);
+        console.log('\n5. url override after a reopen:',
+                    JSON.stringify(elements.mig_api_base_url.value));
+        assert.equal(elements.mig_api_base_url.value, '');
+        assert.equal(elements.mig_deregister.checked, false);
+    }
 
     // 6. Reopen the same flow while the first load is still in flight.
     //    The late one must not append a second copy of the options.
@@ -328,5 +365,113 @@ function jsonResponse(payload) {
         assert.equal(elements.mig_error.textContent, '');
     }
 
-    console.log('\nall ten dialog cases behaved as expected');
+    // 11. The url the operator typed has to leave the browser. Nothing
+    //     else in the suite loads submitMigration, so the field could be
+    //     dropped from the request body and every other case would pass.
+    //     The refusal that follows also has to be painted as a refusal.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement({value: 'vkey-v2-bbbbbb'}),
+            mig_submit: makeElement(),
+            mig_error: makeElement({style: {color: 'var(--on-surface-variant)'}}),
+            mig_deregister: makeElement({checked: true}),
+            mig_api_base_url: makeElement(
+                {value: '  https://v2.example/sumi/flow  '}),
+            'migrate-dialog': makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/flow/x'}}),
+            etag: makeElement({value: 'etag-1'}),
+        };
+        let sent = null;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: 0,
+            hideRegError() {},
+            beginRegistryRequest: () => 1,
+            isCurrentRegistryRequest: () => true,
+            showRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async (url, init) => {
+                sent = JSON.parse(init.body);
+                return {ok: false, status: 422,
+                        json: async () => ({detail: 'api_base_url is wrong'})};
+            },
+            document: {
+                querySelector: () => ({value: 'display: x'}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => elements[id] || null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        await context.submitMigration();
+        console.log('\n11. submit sends the url the operator typed');
+        console.log('   api_base_url :', JSON.stringify(sent.api_base_url));
+        console.log('   wallet_vkey  :', JSON.stringify(sent.wallet_vkey));
+        console.log('   refusal text :', elements.mig_error.textContent);
+        console.log('   refusal colour:',
+                    JSON.stringify(elements.mig_error.style.color));
+        assert.equal(sent.api_base_url, 'https://v2.example/sumi/flow');
+        assert.equal(sent.wallet_vkey, 'vkey-v2-bbbbbb');
+        assert.equal(sent.deregister_previous, true);
+        assert.equal(elements.mig_error.textContent, 'api_base_url is wrong');
+        // A refusal must not inherit the muted colour of a caution.
+        assert.equal(elements.mig_error.style.color, '');
+    }
+
+    // 12. A failed reload must drop the list the previous load produced.
+    //     Without that, the dialog offers a wallet the node has just
+    //     failed to confirm and lets the operator mint against it.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) {
+                    return jsonResponse({wallets: [
+                        {walletVkey: 'vkey-v2-old', walletAddress: 'addr2',
+                         note: 'v2 seller',
+                         paymentSourceType: 'Web3CardanoV2'}]});
+                }
+                return {ok: false, status: 502, json: async () => ({})};
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}]
+                    : (s === 'select.wallet-select' ? [makeElement()] : []),
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        await context.loadWallets();                 // page load succeeds
+        // loadedWallets is a `let`, so it is a lexical binding of the
+        // script and never a property of the context object.
+        assert.equal(vm.runInContext('loadedWallets.length', context), 1);
+        await context.openMigrateDialog(0);          // reload then fails
+        console.log('\n12. failed reload drops the earlier list');
+        console.log('   options :',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        console.log('   dialog  :', elements.mig_error.textContent);
+        console.log('   submit disabled:', elements.mig_submit.disabled);
+        assert.deepEqual(elements.mig_wallet.children, []);
+        assert.equal(elements.mig_submit.disabled, true);
+        assert.match(elements.mig_error.textContent, /HTTP 502/);
+    }
+
+    console.log('\nall twelve dialog cases behaved as expected');
 })();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -41,10 +41,9 @@ assert.ok(helpersEnd > helpersStart);
 const helpersSource = registrySource.slice(helpersStart, helpersEnd);
 
 function makeElement(extra) {
-    return Object.assign({
+    const el = Object.assign({
         value: '',
         textContent: '',
-        innerHTML: '',
         checked: false,
         disabled: false,
         style: {},
@@ -53,6 +52,17 @@ function makeElement(extra) {
         showModal() { this.shown = true; this.open = true; },
         close() { this.open = false; },
     }, extra || {});
+    // Writing innerHTML replaces the children. Modelling it as a plain
+    // field made every missing reset invisible: a select that was never
+    // cleared before it was refilled looked the same as one that was.
+    let html = '';
+    Object.defineProperty(el, 'innerHTML', {
+        get() { return html; },
+        set(value) { html = value; this.children = []; },
+        enumerable: true,
+        configurable: true,
+    });
+    return el;
 }
 
 async function open(responder) {
@@ -503,6 +513,7 @@ function jsonResponse(payload) {
             mig_api_base_url: makeElement(),
             'migrate-dialog': makeElement(),
         };
+        const pageInfo = makeElement();
         let releaseFirst, releaseSecond;
         const first = new Promise((r) => { releaseFirst = r; });
         const second = new Promise((r) => { releaseSecond = r; });
@@ -528,7 +539,7 @@ function jsonResponse(payload) {
                 querySelectorAll: (s) => s === '.registry-section'
                     ? [{id: 'registry_0'}] : [],
                 getElementById: (id) => id === 'reg_info_0'
-                    ? makeElement() : (elements[id] || null),
+                    ? pageInfo : (elements[id] || null),
                 createElement: () => makeElement(),
             },
         };
@@ -553,6 +564,11 @@ function jsonResponse(payload) {
         assert.deepEqual(elements.mig_wallet.children, []);
         assert.equal(elements.mig_submit.disabled, true);
         assert.match(elements.mig_error.textContent, /HTTP 502/);
+        // The dialog reloads quietly, so the failure belongs in the dialog
+        // and nowhere else. Painting the sections here would leave red text
+        // on flows the operator never opened.
+        console.log('   page   :', JSON.stringify(pageInfo.textContent));
+        assert.equal(pageInfo.textContent, '');
     }
 
     // 14. The mirror image: an abandoned FAILURE must not overwrite the
@@ -609,6 +625,11 @@ function jsonResponse(payload) {
         assert.equal(elements.mig_wallet.children.length, 1);
         assert.equal(elements.mig_submit.disabled, false);
         assert.equal(elements.mig_error.textContent, '');
+        // The three assertions above are decided by the dialog's own
+        // generation counter, which predates this fix. The shared state
+        // is what the retirement protects, so read it directly.
+        assert.equal(vm.runInContext('walletLoadError', context), '');
+        assert.equal(vm.runInContext('loadedWallets.length', context), 1);
     }
 
     // 15. A failed load paints every registry section, including flows the
@@ -710,5 +731,274 @@ function jsonResponse(payload) {
         assert.equal(elements.mig_submit.disabled, false);
     }
 
-    console.log('\nall sixteen dialog cases behaved as expected');
+    // 17. Reopening the dialog must not stack a second copy of the same
+    //     wallet on the select. Both renders really happen here, so only
+    //     the clear before the refill can keep the list at one.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => jsonResponse({wallets: [
+                {walletVkey: 'vkey-v2', walletAddress: 'addr',
+                 note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'}]}),
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        await context.openMigrateDialog(0);
+        elements['migrate-dialog'].close();
+        context.activeDialogIdx = null;
+        await context.openMigrateDialog(0);
+        console.log('\n17. reopening does not stack the options');
+        console.log('   options :',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        assert.equal(elements.mig_wallet.children.length, 1);
+    }
+
+    // 18. The same, for the page's own wallet selects, which loadWallets
+    //     refills on every load.
+    {
+        const select = makeElement();
+        const context = {
+            console, exposeName: 'meme-copy', hideRegError() {},
+            fetch: async () => jsonResponse({wallets: [
+                {walletVkey: 'vkey-v2', walletAddress: 'addr',
+                 note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'}]}),
+            document: {
+                querySelectorAll: (s) => s === 'select.wallet-select'
+                    ? [select] : [],
+                getElementById: () => null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource, context);
+        await context.loadWallets();
+        await context.loadWallets();
+        console.log('\n18. a second load refills, it does not append');
+        console.log('   options :',
+                    select.children.map((o) => o.textContent));
+        assert.equal(select.children.length, 1);
+    }
+
+    // 19. A submit that is still in flight when the operator reopens the
+    //     dialog re-enables Migrate from its finally block. The empty-list
+    //     branch has to take the button back, or Migrate sits enabled
+    //     beside the words "could not be listed" with nothing selected.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement({value: 'vkey-v2'}),
+            mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/flow/x'}}),
+            etag: makeElement({value: 'etag-1'}),
+        };
+        elements['migrate-dialog'].showModal();
+        let releasePost, releaseWallets;
+        const post = new Promise((r) => { releasePost = r; });
+        const wallets = new Promise((r) => { releaseWallets = r; });
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: 0,
+            hideRegError() {}, showRegError() {},
+            blockRegistrySync() {}, checkRegistryStatus: async () => {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async (url) => {
+                if (String(url).indexOf('/registry/migrate') !== -1) {
+                    await post;
+                    return {ok: false, status: 422,
+                            json: async () => ({detail: 'nope'})};
+                }
+                await wallets;
+                return {ok: false, status: 502, json: async () => ({})};
+            },
+            document: {
+                querySelector: () => ({value: 'display: x'}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(
+            helpersSource + '\n' + walletsSource + '\n' + openSource,
+            context);
+        const submitting = context.submitMigration();
+        context.activeDialogIdx = null;              // Escape
+        elements['migrate-dialog'].close();
+        const reopened = context.openMigrateDialog(0);
+        releasePost();                                // finally re-enables
+        await submitting;
+        releaseWallets();                             // then the load fails
+        await reopened;
+        console.log('\n19. a late submit re-enables Migrate mid-load');
+        console.log('   dialog :', elements.mig_error.textContent);
+        console.log('   submit disabled:', elements.mig_submit.disabled);
+        assert.match(elements.mig_error.textContent, /could be listed/);
+        assert.deepEqual(elements.mig_wallet.children, []);
+        assert.equal(elements.mig_submit.disabled, true);
+    }
+
+    // 20. A retired load whose response is fine and whose json() is what
+    //     straddles the newer load must still write nothing.
+    {
+        let releaseJson;
+        const jsonGate = new Promise((r) => { releaseJson = r; });
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', hideRegError() {},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) {
+                    return {ok: true, status: 200, json: async () => {
+                        await jsonGate;
+                        return {wallets: [
+                            {walletVkey: 'vkey-STALE', walletAddress: 'a',
+                             note: 'stale',
+                             paymentSourceType: 'Web3CardanoV2'}]};
+                    }};
+                }
+                return jsonResponse({wallets: []});
+            },
+            document: {
+                querySelectorAll: () => [],
+                getElementById: () => null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource, context);
+        const first = context.loadWallets();
+        await new Promise((r) => setTimeout(r, 0));
+        const second = context.loadWallets();
+        await second;
+        releaseJson();
+        await first;
+        console.log('\n20. retired between the response and its json');
+        console.log('   loadedWallets:',
+                    vm.runInContext('loadedWallets.length', context));
+        console.log('   walletLoadError:',
+                    JSON.stringify(vm.runInContext('walletLoadError',
+                                                   context)));
+        assert.equal(vm.runInContext('loadedWallets.length', context), 0);
+        assert.match(vm.runInContext('walletLoadError', context),
+                     /No selling wallets found/);
+    }
+
+    // 21. A retired load that throws must not report its failure over the
+    //     live load's good list.
+    {
+        let releaseError;
+        const errorGate = new Promise((r) => { releaseError = r; });
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', hideRegError() {},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) {
+                    await errorGate;
+                    throw new Error('boom');
+                }
+                return jsonResponse({wallets: [
+                    {walletVkey: 'vkey-v2', walletAddress: 'addr',
+                     note: 'v2 seller',
+                     paymentSourceType: 'Web3CardanoV2'}]});
+            },
+            document: {
+                querySelectorAll: (s) => s === 'select.wallet-select'
+                    ? [makeElement()] : [],
+                getElementById: () => null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource, context);
+        const first = context.loadWallets();
+        const second = context.loadWallets();
+        await second;
+        releaseError();
+        await first;
+        console.log('\n21. a retired load throws after a good one landed');
+        console.log('   loadedWallets:',
+                    vm.runInContext('loadedWallets.length', context));
+        console.log('   walletLoadError:',
+                    JSON.stringify(vm.runInContext('walletLoadError',
+                                                   context)));
+        assert.equal(vm.runInContext('loadedWallets.length', context), 1);
+        assert.equal(vm.runInContext('walletLoadError', context), '');
+    }
+
+    // 22. A reason from an earlier load must not survive into a later
+    //     one that worked. Nothing else clears walletLoadError, so a
+    //     stale sentence would sit in the error colour beside a wallet
+    //     the operator can actually migrate to.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                call += 1;
+                return call === 1
+                    ? {ok: false, status: 503, json: async () => ({})}
+                    : jsonResponse({wallets: [
+                        {walletVkey: 'vkey-v2', walletAddress: 'addr',
+                         note: 'v2 seller',
+                         paymentSourceType: 'Web3CardanoV2'}]});
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}]
+                    : (s === 'select.wallet-select' ? [makeElement()] : []),
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        await context.loadWallets();                 // fails, sets a reason
+        assert.match(vm.runInContext('walletLoadError', context), /503/);
+        await context.openMigrateDialog(0);          // then a good reload
+        console.log('\n22. an old reason does not survive a good load');
+        console.log('   dialog :',
+                    JSON.stringify(elements.mig_error.textContent),
+                    'display=', JSON.stringify(elements.mig_error.style.display));
+        console.log('   options:',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        assert.equal(vm.runInContext('walletLoadError', context), '');
+        assert.equal(elements.mig_error.textContent, '');
+        assert.equal(elements.mig_error.style.display, 'none');
+        assert.equal(elements.mig_submit.disabled, false);
+    }
+
+    console.log('\nall twenty-two dialog cases behaved as expected');
 })();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -473,5 +473,172 @@ function jsonResponse(payload) {
         assert.match(elements.mig_error.textContent, /HTTP 502/);
     }
 
-    console.log('\nall twelve dialog cases behaved as expected');
+    // 13. Two loads overlap and the abandoned one lands first. Its answer
+    //     must not refill the list the live load just cleared, or the
+    //     dialog offers a wallet the node no longer reports, with Submit
+    //     enabled, beside the words "could not be loaded".
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        let releaseFirst, releaseSecond;
+        const first = new Promise((r) => { releaseFirst = r; });
+        const second = new Promise((r) => { releaseSecond = r; });
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) {
+                    await first;
+                    return jsonResponse({wallets: [
+                        {walletVkey: 'vkey-v2-STALE', walletAddress: 'addr',
+                         note: 'wallet from the abandoned load',
+                         paymentSourceType: 'Web3CardanoV2'}]});
+                }
+                await second;
+                return {ok: false, status: 502, json: async () => ({})};
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        const opened = context.openMigrateDialog(0);
+        elements['migrate-dialog'].close();     // Escape
+        context.activeDialogIdx = null;
+        const reopened = context.openMigrateDialog(0);
+        releaseFirst();                          // the abandoned load lands
+        await new Promise((r) => setTimeout(r, 0));
+        releaseSecond();                         // then the live one fails
+        await Promise.all([opened, reopened]);
+        console.log('\n13. abandoned load lands before the live one');
+        console.log('   options :',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        console.log('   dialog  :', elements.mig_error.textContent);
+        console.log('   submit disabled:', elements.mig_submit.disabled);
+        assert.deepEqual(elements.mig_wallet.children, []);
+        assert.equal(elements.mig_submit.disabled, true);
+        assert.match(elements.mig_error.textContent, /HTTP 502/);
+    }
+
+    // 14. The mirror image: an abandoned FAILURE must not overwrite the
+    //     reason of a load that succeeded after it.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement(), mig_submit: makeElement(),
+            mig_error: makeElement(), mig_deregister: makeElement(),
+            mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+        };
+        let releaseFirst;
+        const first = new Promise((r) => { releaseFirst = r; });
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => {
+                call += 1;
+                if (call === 1) {
+                    await first;
+                    return {ok: false, status: 500, json: async () => ({})};
+                }
+                return jsonResponse({wallets: [
+                    {walletVkey: 'vkey-v2-live', walletAddress: 'addr',
+                     note: 'v2 seller',
+                     paymentSourceType: 'Web3CardanoV2'}]});
+            },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => id === 'reg_info_0'
+                    ? makeElement() : (elements[id] || null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource + '\n' + openSource, context);
+        const opened = context.openMigrateDialog(0);
+        elements['migrate-dialog'].close();
+        context.activeDialogIdx = null;
+        const reopened = context.openMigrateDialog(0);
+        await reopened;
+        releaseFirst();
+        await opened;
+        console.log('\n14. abandoned failure lands after a good load');
+        console.log('   options :',
+                    elements.mig_wallet.children.map((o) => o.textContent));
+        console.log('   dialog  :',
+                    JSON.stringify(elements.mig_error.textContent));
+        assert.equal(elements.mig_wallet.children.length, 1);
+        assert.equal(elements.mig_submit.disabled, false);
+        assert.equal(elements.mig_error.textContent, '');
+    }
+
+    // 15. A failed load paints every registry section, including flows the
+    //     operator never touched. Nothing else takes that message down, so
+    //     a later good load has to.
+    {
+        const info = {0: makeElement(), 1: makeElement()};
+        let call = 0;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: null,
+            hideRegError() {},
+            fetch: async () => {
+                call += 1;
+                return call === 1
+                    ? {ok: false, status: 500, json: async () => ({})}
+                    : jsonResponse({wallets: [
+                        {walletVkey: 'vkey-v2', walletAddress: 'addr',
+                         note: 'v2 seller',
+                         paymentSourceType: 'Web3CardanoV2'}]});
+            },
+            document: {
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}, {id: 'registry_1'}]
+                    : (s === 'select.wallet-select' ? [makeElement()] : []),
+                getElementById: (id) => id === 'reg_info_0' ? info[0]
+                    : (id === 'reg_info_1' ? info[1] : null),
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(walletsSource, context);
+        await context.loadWallets();
+        console.log('\n15. a good load takes down what a bad one wrote');
+        console.log('   after the failure, section 1:',
+                    JSON.stringify(info[1].textContent));
+        assert.match(info[0].textContent, /HTTP 500/);
+        assert.match(info[1].textContent, /HTTP 500/);
+        // updateRegistryUI owns these elements too. A status line it wrote
+        // over the wallet message must survive the clear.
+        info[1].textContent = 'Waiting for on-chain confirmation...';
+        await context.loadWallets();
+        console.log('   after the good load, section 0:',
+                    JSON.stringify(info[0].textContent),
+                    'display=', JSON.stringify(info[0].style.display));
+        console.log('   a status line elsewhere  :',
+                    JSON.stringify(info[1].textContent));
+        assert.equal(info[0].textContent, '');
+        assert.equal(info[0].style.display, 'none');
+        assert.equal(info[1].textContent,
+                     'Waiting for on-chain confirmation...');
+    }
+
+    console.log('\nall fifteen dialog cases behaved as expected');
 })();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -27,6 +27,19 @@ const end = dialogSource.indexOf('\nasync function deregisterPrevious(', start);
 assert.ok(end > start);
 const openSource = dialogSource.slice(start, end);
 
+// The real generation helpers, not stubs. Stubs that ignore their
+// arguments cannot see submitMigration passing the wrong idx or losing
+// the generation, and either mistake silently swallows every refusal.
+const registrySource = fs.readFileSync(
+    'kodosumi/service/admin/templates/expose/_registry_script.html', 'utf8');
+const helpersStart = registrySource.indexOf(
+    'const registryRequestGenerations = {};');
+assert.notEqual(helpersStart, -1);
+const helpersEnd = registrySource.indexOf(
+    '\nfunction getNetworkEl(', helpersStart);
+assert.ok(helpersEnd > helpersStart);
+const helpersSource = registrySource.slice(helpersStart, helpersEnd);
+
 function makeElement(extra) {
     return Object.assign({
         value: '',
@@ -227,7 +240,11 @@ function jsonResponse(payload) {
         vm.createContext(context);
         vm.runInContext(walletsSource + '\n' + openSource, context);
         const first = context.openMigrateDialog(0);
-        context.activeDialogIdx = null;          // Escape closes the dialog
+        // Escape really closes the dialog: oncancel nulls the index and
+        // the element reports itself shut. A test that only nulls the
+        // index leaves .open true and stops testing the real thing.
+        context.activeDialogIdx = null;
+        elements['migrate-dialog'].close();
         const second = context.openMigrateDialog(0);
         await second;
         release();
@@ -290,6 +307,7 @@ function jsonResponse(payload) {
         vm.runInContext(walletsSource + '\n' + openSource, context);
         const pending = context.openMigrateDialog(0);
         context.activeDialogIdx = null;      // Escape closes the dialog
+        elements['migrate-dialog'].close();
         release();
         await pending;
         console.log('\n8. dialog closed while the quiet load failed');
@@ -386,8 +404,6 @@ function jsonResponse(payload) {
         const context = {
             console, exposeName: 'meme-copy', activeDialogIdx: 0,
             hideRegError() {},
-            beginRegistryRequest: () => 1,
-            isCurrentRegistryRequest: () => true,
             showRegError() {},
             jsyaml: {load: () => ({agentIdentifier: 'a'})},
             fetch: async (url, init) => {
@@ -404,7 +420,9 @@ function jsonResponse(payload) {
             },
         };
         vm.createContext(context);
-        vm.runInContext(walletsSource + '\n' + openSource, context);
+        vm.runInContext(
+            helpersSource + '\n' + walletsSource + '\n' + openSource,
+            context);
         await context.submitMigration();
         console.log('\n11. submit sends the url the operator typed');
         console.log('   api_base_url :', JSON.stringify(sent.api_base_url));
@@ -517,6 +535,9 @@ function jsonResponse(payload) {
         vm.createContext(context);
         vm.runInContext(walletsSource + '\n' + openSource, context);
         const opened = context.openMigrateDialog(0);
+        // The dialog is on screen for the whole load, so Migrate has to be
+        // disabled from the moment it opens, not only once a list arrives.
+        assert.equal(elements.mig_submit.disabled, true);
         elements['migrate-dialog'].close();     // Escape
         context.activeDialogIdx = null;
         const reopened = context.openMigrateDialog(0);
@@ -640,5 +661,54 @@ function jsonResponse(payload) {
                      'Waiting for on-chain confirmation...');
     }
 
-    console.log('\nall fifteen dialog cases behaved as expected');
+    // 16. The network drops mid-submit. Nothing else runs this branch, so
+    //     without it the refusal colour there rests on a text scan that a
+    //     reformat could satisfy while the bug stayed.
+    {
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement({value: 'vkey-v2'}),
+            mig_submit: makeElement(),
+            mig_error: makeElement(
+                {style: {color: 'var(--on-surface-variant)'}}),
+            mig_deregister: makeElement(), mig_api_base_url: makeElement(),
+            'migrate-dialog': makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/flow/x'}}),
+            etag: makeElement({value: 'etag-1'}),
+        };
+        let blocked = null;
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: 0,
+            hideRegError() {}, showRegError() {},
+            blockRegistrySync: (idx, message) => { blocked = message; },
+            checkRegistryStatus: async () => {},
+            jsyaml: {load: () => ({agentIdentifier: 'a'})},
+            fetch: async () => { throw new Error('Failed to fetch'); },
+            document: {
+                querySelector: () => ({value: 'display: x'}),
+                querySelectorAll: (s) => s === '.registry-section'
+                    ? [{id: 'registry_0'}] : [],
+                getElementById: (id) => elements[id] || null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(
+            helpersSource + '\n' + walletsSource + '\n' + openSource,
+            context);
+        await context.submitMigration();
+        console.log('\n16. the network drops mid-submit');
+        console.log('   dialog :', elements.mig_error.textContent);
+        console.log('   colour :',
+                    JSON.stringify(elements.mig_error.style.color));
+        console.log('   blocked:', blocked);
+        assert.equal(elements.mig_error.textContent,
+                     'Network error: Failed to fetch');
+        assert.equal(elements.mig_error.style.color, '');
+        assert.match(blocked, /Reload the page/);
+        // The finally block hands the button back once the dialog is free.
+        assert.equal(elements.mig_submit.disabled, false);
+    }
+
+    console.log('\nall sixteen dialog cases behaved as expected');
 })();

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -259,5 +259,26 @@ function jsonResponse(payload) {
         assert.match(info.textContent, /HTTP 500/);
     }
 
-    console.log('\nall eight dialog cases behaved as expected');
+    // 9. Every write into the migrate error element has to set its colour
+    //    too. The element carries a muted caution and a red refusal in the
+    //    same dialog, so a write that leaves the colour alone inherits the
+    //    previous meaning: a refused submit rendered as a mild note.
+    {
+        const lines = dialogSource.split('\n');
+        const offenders = [];
+        lines.forEach((line, i) => {
+            if (!/errEl\.textContent\s*=/.test(line)) return;
+            // The colour may be set on either side of the write, so read a
+            // window around it rather than only what came before.
+            const window = lines.slice(Math.max(0, i - 3), i + 4).join('\n');
+            if (!/errEl\.style\.color\s*=/.test(window)) {
+                offenders.push(i + 1);
+            }
+        });
+        console.log('\n9. error element writes that set a colour');
+        console.log('   writes without one, by line:', offenders);
+        assert.deepEqual(offenders, []);
+    }
+
+    console.log('\nall nine dialog cases behaved as expected');
 })();

--- a/tests/test_pr88_sumi_and_wallets.py
+++ b/tests/test_pr88_sumi_and_wallets.py
@@ -440,7 +440,8 @@ async def test_wallet_fetches_use_the_named_concurrency_limit():
     max_active_requests = 0
 
     async def fetch_wallets(
-        _client, _masumi, _headers, source_id, _require_complete=False
+        _client, _masumi, _headers, source_id, _require_complete=False,
+        _report=None
     ):
         nonlocal active_requests, max_active_requests
         active_requests += 1

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -612,7 +612,47 @@ class TestMigrateApiBaseUrl:
 
     @pytest.mark.asyncio
     async def test_a_non_string_is_refused_with_a_reason(self):
-        for value in (42, ["https://a"], {"u": "x"}):
+        # The falsy ones matter most: reading the field with "or" turns
+        # them into "" and drops them silently, so a caller who sent the
+        # wrong type gets a mint against the default url and no warning.
+        for value in (42, ["https://a"], {"u": "x"}, 0, False, [], {}):
+            with pytest.raises(ClientException) as err:
+                await _call_migrate({"api_base_url": value})
+            assert err.value.status_code == 422, value
+
+    @pytest.mark.asyncio
+    async def test_a_host_two_parsers_read_differently_is_refused(self):
+        # urlparse follows RFC 3986 and every client follows the WHATWG
+        # url standard. A backslash is an ordinary host character to the
+        # first and a separator to the second, so approving a host here
+        # and handing a buyer another one is the failure to avoid.
+        # "https://good.com\\@evil.com" is evil.com to urlparse and
+        # good.com to a browser.
+        for value in ("http://exa\\mple.com/sumi/flow",
+                      "https://good.com\\@evil.com/sumi",
+                      # A fraction slash reads as a path and mints a host.
+                      "http://example.com\u2044evil/sumi",
+                      # A backslash below the host diverges too: a client
+                      # calls /pa/th where urlparse sees /pa\\th.
+                      "https://host.example/pa\\th",
+                      # A raw IDN has to be entered as punycode, which is
+                      # what DNS carries and what both parsers agree on.
+                      "https://\u4f8b\u3048.jp/sumi",
+                      # A zone id names a link on this machine. No buyer
+                      # can call it, and Node refuses to parse it at all.
+                      "http://[fe80::1%25eth0]/sumi"):
+            with pytest.raises(ClientException) as err:
+                await _call_migrate({"api_base_url": value})
+            assert err.value.status_code == 422, value
+
+    @pytest.mark.asyncio
+    async def test_credentials_in_the_authority_are_refused(self):
+        # The value is minted into a public registry entry that nobody can
+        # edit afterwards, so a password pasted with the host would stay
+        # readable on chain for good. parsed.hostname strips the userinfo,
+        # so the host check alone never sees it.
+        for value in ("https://ops:hunter2@agents.example/sumi/flow",
+                      "https://ops@agents.example/sumi"):
             with pytest.raises(ClientException) as err:
                 await _call_migrate({"api_base_url": value})
             assert err.value.status_code == 422, value

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -658,7 +658,19 @@ class TestMigrateApiBaseUrl:
                       "http://0x7f.1/sumi",
                       "http://api.example.123/sumi",
                       "http://1.2.3.4.5/sumi",
-                      "http://999.999.999.999/sumi"):
+                      "http://999.999.999.999/sumi",
+                      # A root dot makes the last label empty, which used
+                      # to skip the whole rule. Node still reads every one
+                      # of these as a number: 0177.0.0.1. is 127.0.0.1 and
+                      # 010.0.0.1. is 8.0.0.1, a third party's address.
+                      "http://0177.0.0.1./sumi/flow",
+                      "http://010.0.0.1./sumi",
+                      "http://2130706433./sumi",
+                      "http://0x7f000001./sumi",
+                      "http://999999999999./sumi",
+                      # Even the plain quad disagrees once it carries the
+                      # dot: urlparse keeps it, Node drops it.
+                      "http://10.0.0.7./sumi"):
             with pytest.raises(ClientException) as err:
                 await _call_migrate({"api_base_url": value})
             assert err.value.status_code == 422, value
@@ -670,7 +682,11 @@ class TestMigrateApiBaseUrl:
         for value in ("http://10.0.0.7/sumi", "http://0.0.0.0/sumi",
                       "http://255.255.255.255/sumi",
                       "https://4you.example.com/sumi",
-                      "https://host.4you/sumi"):
+                      "https://host.4you/sumi",
+                      # A fully qualified name keeps its root dot in both
+                      # parsers, so it is not a disagreement.
+                      "http://example.com./sumi",
+                      "https://sub.example.com.:8443/sumi"):
             _, _, register = await _call_migrate({"api_base_url": value})
             assert register.call_args.kwargs["api_base_url"] == value
 

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -583,7 +583,11 @@ class TestMigrateApiBaseUrl:
                       "http://:8080", "http://@",
                       # Invisible characters survive a copy out of a doc
                       # and cannot be spotted in the field afterwards.
-                      "http://a\x00b", "http://\u200bexample.com"):
+                      "http://a\x00b", "http://\u200bexample.com",
+                      # A letter O for a zero in the port, and a host that
+                      # is punctuation only.
+                      "http://example.com:8O80/sumi", "http://.",
+                      "http://-", "http://%00"):
             with pytest.raises(ClientException) as err:
                 await _call_migrate({"api_base_url": value})
             assert err.value.status_code == 422, value
@@ -595,6 +599,16 @@ class TestMigrateApiBaseUrl:
             {"api_base_url": "HTTPS://Example.com/sumi/flow"})
         assert register.call_args.kwargs["api_base_url"] == \
             "HTTPS://Example.com/sumi/flow"
+
+    @pytest.mark.asyncio
+    async def test_the_shapes_a_real_deployment_uses_are_accepted(self):
+        for value in ("https://host.example/sumi/flow",
+                      "http://localhost:3370/sumi/flow",
+                      "http://[::1]:8080/sumi",
+                      "https://xn--mnchen-3ya.de/sumi",
+                      "https://a.example:8443/sumi?x=1#y"):
+            _, _, register = await _call_migrate({"api_base_url": value})
+            assert register.call_args.kwargs["api_base_url"] == value
 
     @pytest.mark.asyncio
     async def test_a_non_string_is_refused_with_a_reason(self):

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -538,3 +538,37 @@ class TestDeregisterPrevious:
             result = await task
         assert result["success"] is True
         assert deregister.call_args.args[1] == "v1-agent"
+
+
+class TestMigrateApiBaseUrl:
+    """The url the new agent advertises is minted on chain.
+
+    kodosumi never calls the payment node's update endpoint, so a url that
+    is wrong at mint time cannot be corrected from here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_the_url_of_the_v1_listing(self):
+        _, _, register = await _call_migrate()
+        assert register.call_args.kwargs["api_base_url"] == \
+            "https://host/sumi/flow"
+
+    @pytest.mark.asyncio
+    async def test_an_override_replaces_it(self):
+        _, _, register = await _call_migrate(
+            {"api_base_url": "https://v2.example.com/sumi/flow"})
+        assert register.call_args.kwargs["api_base_url"] == \
+            "https://v2.example.com/sumi/flow"
+
+    @pytest.mark.asyncio
+    async def test_an_empty_override_keeps_the_default(self):
+        _, _, register = await _call_migrate({"api_base_url": "   "})
+        assert register.call_args.kwargs["api_base_url"] == \
+            "https://host/sumi/flow"
+
+    @pytest.mark.asyncio
+    async def test_a_relative_override_is_refused_before_the_mint(self):
+        with pytest.raises(ClientException) as err:
+            await _call_migrate({"api_base_url": "/sumi/flow"})
+        assert err.value.status_code == 422
+        assert "http://" in err.value.detail

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -578,7 +578,12 @@ class TestMigrateApiBaseUrl:
         # A truncated paste passes a startswith check and mints an agent
         # that no buyer can reach.
         for value in ("http://", "https://", "https:// evil.com",
-                      "http://a\nb"):
+                      "http://a\nb",
+                      # A netloc is not a host: both of these have one.
+                      "http://:8080", "http://@",
+                      # Invisible characters survive a copy out of a doc
+                      # and cannot be spotted in the field afterwards.
+                      "http://a\x00b", "http://\u200bexample.com"):
             with pytest.raises(ClientException) as err:
                 await _call_migrate({"api_base_url": value})
             assert err.value.status_code == 422, value

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -572,3 +572,28 @@ class TestMigrateApiBaseUrl:
             await _call_migrate({"api_base_url": "/sumi/flow"})
         assert err.value.status_code == 422
         assert "http://" in err.value.detail
+
+    @pytest.mark.asyncio
+    async def test_a_scheme_without_a_host_is_refused(self):
+        # A truncated paste passes a startswith check and mints an agent
+        # that no buyer can reach.
+        for value in ("http://", "https://", "https:// evil.com",
+                      "http://a\nb"):
+            with pytest.raises(ClientException) as err:
+                await _call_migrate({"api_base_url": value})
+            assert err.value.status_code == 422, value
+
+    @pytest.mark.asyncio
+    async def test_an_uppercase_scheme_is_accepted(self):
+        # RFC 3986 schemes are case insensitive, so this is a legal url.
+        _, _, register = await _call_migrate(
+            {"api_base_url": "HTTPS://Example.com/sumi/flow"})
+        assert register.call_args.kwargs["api_base_url"] == \
+            "HTTPS://Example.com/sumi/flow"
+
+    @pytest.mark.asyncio
+    async def test_a_non_string_is_refused_with_a_reason(self):
+        for value in (42, ["https://a"], {"u": "x"}):
+            with pytest.raises(ClientException) as err:
+                await _call_migrate({"api_base_url": value})
+            assert err.value.status_code == 422, value

--- a/tests/test_registry_migrate_endpoint.py
+++ b/tests/test_registry_migrate_endpoint.py
@@ -646,6 +646,44 @@ class TestMigrateApiBaseUrl:
             assert err.value.status_code == 422, value
 
     @pytest.mark.asyncio
+    async def test_a_host_that_reads_as_a_number_is_refused(self):
+        # A client reads any host whose last label is a number as an IPv4
+        # address, in whatever base the digits imply. urlparse never does.
+        # "http://0177.0.0.1" is a public address to the server and
+        # loopback to the buyer, and "http://api.example.123" is a host to
+        # the server and a parse error to the buyer.
+        for value in ("http://0177.0.0.1/sumi/flow",
+                      "http://192.168.010.1/sumi",
+                      "http://2130706433/sumi",
+                      "http://0x7f.1/sumi",
+                      "http://api.example.123/sumi",
+                      "http://1.2.3.4.5/sumi",
+                      "http://999.999.999.999/sumi"):
+            with pytest.raises(ClientException) as err:
+                await _call_migrate({"api_base_url": value})
+            assert err.value.status_code == 422, value
+
+    @pytest.mark.asyncio
+    async def test_the_plain_forms_of_a_number_host_are_accepted(self):
+        # The decimal dotted quad means the same to both parsers, and a
+        # label that merely starts with a digit is a name, not a number.
+        for value in ("http://10.0.0.7/sumi", "http://0.0.0.0/sumi",
+                      "http://255.255.255.255/sumi",
+                      "https://4you.example.com/sumi",
+                      "https://host.4you/sumi"):
+            _, _, register = await _call_migrate({"api_base_url": value})
+            assert register.call_args.kwargs["api_base_url"] == value
+
+    @pytest.mark.asyncio
+    async def test_an_underscore_host_is_accepted(self):
+        # Both parsers keep an underscore and RFC 2181 allows it, so a
+        # compose service name is a legitimate deployment shape.
+        for value in ("http://kodosumi_app:3370/sumi/flow",
+                      "https://my_agent.example.com/sumi"):
+            _, _, register = await _call_migrate({"api_base_url": value})
+            assert register.call_args.kwargs["api_base_url"] == value
+
+    @pytest.mark.asyncio
     async def test_credentials_in_the_authority_are_refused(self):
         # The value is minted into a public registry entry that nobody can
         # edit afterwards, so a password pasted with the host would stay

--- a/tests/test_wallet_inventory.py
+++ b/tests/test_wallet_inventory.py
@@ -173,6 +173,53 @@ class TestListWalletsReport:
         assert report.problems == []
 
     @pytest.mark.asyncio
+    async def test_records_a_payment_source_page_it_could_not_follow(self):
+        # The node's cursor is the id of the last row. A full page whose
+        # last row carries no id ends the paging early, and the sources
+        # beyond it are never read. Without a recorded problem the caller
+        # reads that truncated list as the whole list, and the panel says
+        # "add a wallet" about a V2 source it never saw.
+        # Every row on this page is for another network, so no wallet
+        # request follows and the truncation is the only event.
+        page = [{"id": f"src-{i}", "network": "Preprod",
+                 "paymentSourceType": "Web3CardanoV1"} for i in range(99)]
+        page.append({"network": "Preprod",
+                     "paymentSourceType": "Web3CardanoV1"})
+        report = WalletReport()
+        _, patched = _patch_registry_client(
+            [_json_response({"data": {"PaymentSources": page}})])
+        with patched:
+            await list_wallets(_make_config(), report=report)
+
+        assert len(report.problems) == 1
+        assert "could not be paged past" in report.problems[0]
+        assert "may be incomplete" in report.describe_partial()
+
+    @pytest.mark.asyncio
+    async def test_records_a_wallet_page_it_could_not_follow(self):
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-main", "network": "Mainnet",
+             "paymentSourceType": "Web3CardanoV2"},
+        ]}})
+        wallet_page = [{"id": f"w-{i}", "walletVkey": f"vkey-{i}",
+                        "walletAddress": "addr1", "note": "seller"}
+                       for i in range(99)]
+        wallet_page.append({"walletVkey": "vkey-last",
+                            "walletAddress": "addr1", "note": "seller"})
+        report = WalletReport()
+        _, patched = _patch_registry_client(
+            [sources, _json_response({"data": {"Wallets": wallet_page}})])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        # The list that did arrive is still offered. It is the silence
+        # about the rest that this guards against.
+        assert len(wallets) == 100
+        assert len(report.problems) == 1
+        assert "could not be paged past" in report.problems[0]
+        assert "src-main" in report.problems[0]
+
+    @pytest.mark.asyncio
     async def test_records_a_wallet_request_that_raised(self):
         # asyncio.gather returns the exception rather than raising it, and
         # an unrecorded exception left the panel saying "add a wallet"

--- a/tests/test_wallet_inventory.py
+++ b/tests/test_wallet_inventory.py
@@ -64,15 +64,39 @@ class TestDescribeEmpty:
         assert "KODO_MASUMI" in message
 
     def test_other_network_names_what_the_token_sees(self):
-        report = WalletReport(source_count=2, networks=["Preprod"])
+        report = WalletReport(
+            source_count=2, matched_count=0, networks=["Preprod"])
         message = report.describe_empty("Mainnet")
         assert "Preprod" in message
         assert "network limit" in message
 
     def test_right_network_without_a_wallet_asks_for_a_wallet(self):
-        report = WalletReport(source_count=1, networks=["Mainnet"])
+        report = WalletReport(
+            source_count=1, matched_count=1, networks=["Mainnet"])
         message = report.describe_empty("Mainnet")
         assert "has a selling wallet yet" in message
+
+    def test_a_source_without_a_network_still_counts_as_matched(self):
+        # list_wallets keeps a source whose row carries no network, so a
+        # report that judged by the networks list alone would blame the
+        # token for a source it did read.
+        report = WalletReport(source_count=1, matched_count=1, networks=[])
+        message = report.describe_empty("Mainnet")
+        assert "has a selling wallet yet" in message
+        assert "network limit" not in message
+
+    def test_a_clean_run_has_nothing_to_warn_about(self):
+        assert WalletReport(source_count=1, matched_count=1) \
+            .describe_partial() is None
+
+    def test_a_failed_request_warns_even_with_wallets_in_hand(self):
+        report = WalletReport(
+            source_count=2, matched_count=2,
+            problems=["GET /wallet for payment source src-v2 answered "
+                      "HTTP 503"])
+        warning = report.describe_partial()
+        assert "may be incomplete" in warning
+        assert "HTTP 503" in warning
 
 
 class TestListWalletsReport:
@@ -147,3 +171,92 @@ class TestListWalletsReport:
         assert [w["walletVkey"] for w in wallets] == ["vkey-1"]
         assert wallets[0]["paymentSourceType"] == "Web3CardanoV2"
         assert report.problems == []
+
+    @pytest.mark.asyncio
+    async def test_records_a_wallet_request_that_raised(self):
+        # asyncio.gather returns the exception rather than raising it, and
+        # an unrecorded exception left the panel saying "add a wallet"
+        # about a node it could not reach.
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-main", "network": "Mainnet",
+             "paymentSourceType": "Web3CardanoV2"},
+        ]}})
+        report = WalletReport()
+        client = AsyncMock()
+        client.__aenter__.return_value = client
+        client.__aexit__.return_value = None
+        client.get.side_effect = [sources, OSError("connection refused")]
+        with patch("kodosumi.service.expose.registry.HTTPXClient",
+                   MagicMock(return_value=client)):
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert wallets == []
+        assert len(report.problems) == 1
+        assert "connection refused" in report.problems[0]
+        assert "connection refused" in report.describe_empty("Mainnet")
+
+
+class TestWalletsEndpoint:
+    """The endpoint answers with the node's network name and its evidence."""
+
+    def _state(self, config_name):
+        settings = MagicMock()
+        settings.get_masumi.return_value = _make_config(network=config_name)
+        return {"settings": settings}
+
+    async def _call(self, list_impl, config_name="Mainnet"):
+        from kodosumi.service.expose.wallet_control import WalletsControl
+        handler = getattr(WalletsControl.list_wallets, "fn",
+                          WalletsControl.list_wallets)
+        with patch("kodosumi.service.expose.wallet_control.db.init_database",
+                   new_callable=AsyncMock), \
+             patch("kodosumi.service.expose.wallet_control.db.get_expose",
+                   new_callable=AsyncMock,
+                   return_value={"name": "x", "network": config_name}), \
+             patch("kodosumi.service.expose.registry.list_wallets",
+                   new=list_impl):
+            return await handler(WalletsControl, name="x",
+                                 state=self._state(config_name))
+
+    @pytest.mark.asyncio
+    async def test_empty_list_quotes_the_network_the_node_knows(self):
+        # The expose row holds the KODO_MASUMI entry name, which is free
+        # text. Comparing it against the node's own network values made the
+        # endpoint blame the token for a payment source it had just read.
+        async def fake(masumi, require_complete=False, report=None):
+            report.source_count = 1
+            report.matched_count = 1
+            report.networks = ["Mainnet"]
+            return []
+
+        result = await self._call(fake, config_name="Mainnet-prod")
+        assert result["wallets"] == []
+        assert "has a selling wallet yet" in result["error"]
+        assert "Mainnet-prod" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_partial_list_is_returned_with_a_warning(self):
+        async def fake(masumi, require_complete=False, report=None):
+            report.source_count = 2
+            report.matched_count = 2
+            report.problems.append(
+                "GET /wallet for payment source src-v2 answered HTTP 503")
+            return [{"walletVkey": "vkey-1",
+                     "paymentSourceType": "Web3CardanoV1"}]
+
+        result = await self._call(fake)
+        assert len(result["wallets"]) == 1
+        assert "error" not in result
+        assert "HTTP 503" in result["warning"]
+
+    @pytest.mark.asyncio
+    async def test_a_clean_list_carries_no_warning(self):
+        async def fake(masumi, require_complete=False, report=None):
+            report.source_count = 1
+            report.matched_count = 1
+            return [{"walletVkey": "vkey-1",
+                     "paymentSourceType": "Web3CardanoV2"}]
+
+        result = await self._call(fake)
+        assert "warning" not in result
+        assert "error" not in result

--- a/tests/test_wallet_inventory.py
+++ b/tests/test_wallet_inventory.py
@@ -220,6 +220,45 @@ class TestListWalletsReport:
         assert "src-main" in report.problems[0]
 
     @pytest.mark.asyncio
+    async def test_names_an_exception_that_carries_no_message(self):
+        # Every httpx timeout stringifies to "". Without the class name
+        # the panel showed the operator a sentence that ended in a colon
+        # and said nothing, which is the state this evidence replaces.
+        import httpx
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-main", "network": "Mainnet",
+             "paymentSourceType": "Web3CardanoV2"},
+        ]}})
+        report = WalletReport()
+        client = AsyncMock()
+        client.__aenter__.return_value = client
+        client.__aexit__.return_value = None
+        client.get.side_effect = [sources, httpx.ReadTimeout("")]
+        with patch("kodosumi.service.expose.registry.HTTPXClient",
+                   MagicMock(return_value=client)):
+            await list_wallets(_make_config(), report=report)
+
+        assert report.problems == [
+            "GET /wallet for payment source src-main failed: ReadTimeout"]
+        assert report.describe_empty("Mainnet").endswith("ReadTimeout")
+
+    @pytest.mark.asyncio
+    async def test_records_a_source_that_arrived_without_an_id(self):
+        # No id means no way to ask for that source's wallets. Silence
+        # here reads as "this source has no selling wallet".
+        sources = _json_response({"data": {"PaymentSources": [
+            {"network": "Mainnet", "paymentSourceType": "Web3CardanoV2"},
+        ]}})
+        report = WalletReport()
+        _, patched = _patch_registry_client([sources])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert wallets == []
+        assert len(report.problems) == 1
+        assert "without an id" in report.problems[0]
+
+    @pytest.mark.asyncio
     async def test_records_a_wallet_request_that_raised(self):
         # asyncio.gather returns the exception rather than raising it, and
         # an unrecorded exception left the panel saying "add a wallet"

--- a/tests/test_wallet_inventory.py
+++ b/tests/test_wallet_inventory.py
@@ -1,0 +1,149 @@
+"""
+Tests for the evidence a wallet listing keeps about itself.
+
+An empty selling wallet list used to read "No selling wallets found for
+network X. Check your Masumi Payment API token and configuration" no
+matter what caused it, and the migrate dialog turned the same emptiness
+into "No Web3CardanoV2 selling wallet on this network". Both sentences
+name a cause the code never checked. These tests pin the causes apart.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from kodosumi.config import MasumiConfig
+from kodosumi.service.expose.registry import list_wallets
+from kodosumi.service.expose.wallet_inventory import WalletReport
+
+
+def _make_config(**overrides) -> MasumiConfig:
+    defaults = dict(
+        network="Mainnet",
+        base_url="https://test.masumi.network/api/v1",
+        token="test-token",
+        poll_interval=1.0,
+    )
+    defaults.update(overrides)
+    return MasumiConfig(**defaults)
+
+
+def _json_response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = ""
+    response.json.return_value = payload
+    return response
+
+
+def _patch_registry_client(get_responses):
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    client.get.side_effect = list(get_responses)
+    factory = MagicMock(return_value=client)
+    return client, patch(
+        "kodosumi.service.expose.registry.HTTPXClient", factory)
+
+
+class TestDescribeEmpty:
+    """Every cause of an empty list gets its own sentence."""
+
+    def test_failed_request_is_quoted(self):
+        report = WalletReport(
+            source_count=1,
+            networks=["Mainnet"],
+            problems=["GET /payment-source answered HTTP 401"],
+        )
+        message = report.describe_empty("Mainnet")
+        assert "HTTP 401" in message
+        assert "no selling wallet" not in message.lower()
+
+    def test_no_visible_source_blames_the_token_or_the_node(self):
+        message = WalletReport().describe_empty("Mainnet")
+        assert "no payment source at all" in message
+        assert "KODO_MASUMI" in message
+
+    def test_other_network_names_what_the_token_sees(self):
+        report = WalletReport(source_count=2, networks=["Preprod"])
+        message = report.describe_empty("Mainnet")
+        assert "Preprod" in message
+        assert "network limit" in message
+
+    def test_right_network_without_a_wallet_asks_for_a_wallet(self):
+        report = WalletReport(source_count=1, networks=["Mainnet"])
+        message = report.describe_empty("Mainnet")
+        assert "has a selling wallet yet" in message
+
+
+class TestListWalletsReport:
+    """The report carries what the node showed, not what was asked for."""
+
+    @pytest.mark.asyncio
+    async def test_records_every_visible_source_before_the_filter(self):
+        # A token limited to Preprod answers 200 with Preprod rows only.
+        # The wallet list is empty for Mainnet, and only the report can
+        # say that the token never saw a Mainnet source.
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-preprod", "network": "Preprod",
+             "paymentSourceType": "Web3CardanoV1"},
+        ]}})
+        report = WalletReport()
+        _, patched = _patch_registry_client([sources])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert wallets == []
+        assert report.source_count == 1
+        assert report.networks == ["Preprod"]
+        assert report.problems == []
+        assert "Preprod" in report.describe_empty("Mainnet")
+
+    @pytest.mark.asyncio
+    async def test_records_a_refused_payment_source_request(self):
+        report = WalletReport()
+        _, patched = _patch_registry_client(
+            [_json_response({}, status_code=401)])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert wallets == []
+        assert report.problems == [
+            "GET /payment-source answered HTTP 401"]
+        assert "HTTP 401" in report.describe_empty("Mainnet")
+
+    @pytest.mark.asyncio
+    async def test_records_a_refused_wallet_request(self):
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-main", "network": "Mainnet",
+             "paymentSourceType": "Web3CardanoV2"},
+        ]}})
+        report = WalletReport()
+        _, patched = _patch_registry_client(
+            [sources, _json_response({}, status_code=403)])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert wallets == []
+        assert report.source_count == 1
+        assert report.problems == [
+            "GET /wallet for payment source src-main answered HTTP 403"]
+
+    @pytest.mark.asyncio
+    async def test_a_clean_run_reports_no_problem(self):
+        sources = _json_response({"data": {"PaymentSources": [
+            {"id": "src-main", "network": "Mainnet",
+             "paymentSourceType": "Web3CardanoV2",
+             "smartContractAddress": "addr_test1contract"},
+        ]}})
+        wallets_page = _json_response({"data": {"Wallets": [
+            {"id": "w1", "walletVkey": "vkey-1",
+             "walletAddress": "addr1", "note": "seller"},
+        ]}})
+        report = WalletReport()
+        _, patched = _patch_registry_client([sources, wallets_page])
+        with patched:
+            wallets = await list_wallets(_make_config(), report=report)
+
+        assert [w["walletVkey"] for w in wallets] == ["vkey-1"]
+        assert wallets[0]["paymentSourceType"] == "Web3CardanoV2"
+        assert report.problems == []


### PR DESCRIPTION
Follow-up to #88. The migrate dialog refused to offer any wallet, and the reason it gave was not the reason.

## The bug

An operator with a working Mainnet payment source and a funded selling wallet saw:

> No Web3CardanoV2 selling wallet on this network. Add one in the Masumi payment service first.

The endpoint behind it returned no wallets at all, V1 included:

```
await (await fetch('/expose/meme-copy/wallets', {credentials:'same-origin'})).json()
{wallets: [], error: "No selling wallets found for network 'Mainnet'. Check your Masumi Payment API token and configuration."}
```

Both `GET /payment-source` and `GET /wallet` on the payment node filter server-side by the API key's `networkLimit` and answer `200` with an empty list. A key limited to Preprod, a node that holds no source for this network, and a source with no selling wallet are indistinguishable from the response alone. The panel picked one of those causes and printed it as fact, which sent the operator looking for a wallet that was never missing.

The `?network=` parameter kodosumi sent to `/payment-source` was never accepted by the service. VERIFIED in the sibling repo: `src/routes/api/payment-source/schemas.ts` accepts only `take` and `cursorId`, and `queries.ts` filters on `network: { in: networkLimit }`.

## What changed

### The listing carries its evidence

`WalletReport` records how many payment sources the token could read, how many survived the network filter, which networks it saw, and every request that did not answer. `describe_empty()` then names the cause instead of guessing at it, and a list that is only partly loaded gets a `warning` beside the wallets rather than an error instead of them.

### The dialog reloads and quotes the real reason

`openMigrateDialog` is async, shows the modal first, reloads the list quietly, and guards the late answer with a generation counter. A failed load no longer reads as a missing wallet.

### A migration can set the URL its new agent advertises

New optional field on the migrate dialog. The value is minted on chain and kodosumi never calls the node's update endpoint, so a wrong URL cannot be corrected from here. It is validated against what a client will actually parse: no backslash, no userinfo, and a host from an ASCII allowlist or a bracketed IPv6 literal.

### An abandoned wallet load could poison the live one

`loadedWallets` is shared and nothing retired a fetch whose dialog had been closed. Open Migrate, press Escape, open it again, and the first answer could land after the second load had cleared the list: the dialog then offered a wallet the node no longer reports, with Submit enabled, next to "Wallets could not be loaded (HTTP 502)". The browser auto-selects a sole option, so that wallet was one click from a mint. `loadWallets` now has its own generation counter.

### A failed load painted every flow red, permanently

`hideRegError` clears a different element and `updateRegistryUI` only clears its own sentences, so the message survived until a full reload, on flows the operator never touched. A later good load now clears it, and only where the text is still the one it wrote.

### The name pattern was silently dead

`pattern="^[a-z0-9][a-z0-9_-]*$"` validated nothing. A literal trailing hyphen in a character class is a SyntaxError under the `v` flag, and an uncompilable `pattern` is ignored, so the field validated nothing:

```
/^[a-z0-9][a-z0-9_-]*$/v   -> SyntaxError: Invalid character in character class
/^[a-z0-9][a-z0-9_\-]*$/v  -> compiles
```

A URL is validated against what a client will actually parse, not against what `urlparse` reports. The two disagree on backslashes, on non-ASCII hosts, and on any host whose last label is a number: `http://0177.0.0.1` is a public address to Python and loopback to every browser, and `http://api.example.123` is a host to Python and `Invalid URL` to Node.

## Deliberate narrowings

A raw IDN host (`https://例え.jp`) must be entered as punycode. An IPv6 zone id (`http://[fe80::1%25eth0]/sumi`) is refused: Node will not parse it, so no buyer could call it. A number may appear in a host only as a plain decimal dotted quad. `host.4you` and `kodosumi_app` stay accepted. All of these are recorded in the code comments and covered by tests.

## One refactor

`registry.py` reached 742 of the 750 lines this project allows a source file, so the price translation moved to `pricing.py` with the constants only it uses. Every name is re-exported from `registry`, so no caller changes.

## Verification

- `490 passed` across the 21 test files that import the changed modules.
- `all sixteen dialog cases behaved as expected` (`node tests/test_migrate_dialog.js`), driving the real template JavaScript, including the real generation helpers rather than stubs.
- Six backend cases over real HTTP through the real Litestar controller against a stub payment node.
- Every fix has a mutant that kills it. Each was run alone with a restore in between.

Pre-existing and untouched: `tests/test_boot_step_a.py` and `tests/test_boot_step_c.py` have 3 failures that fail identically at base commit `34d9cce`, all `AssertionError: Expected 'post' to have been called once. Called 0 times.`

## Follow-up

`kodosumi/service/expose/boot.py` is 3059 lines against the 750-line ceiling. Pre-existing, untouched here.
