### PR TITLE
fix(expose): read selling wallets from /wallet/list, not /wallet

### DIFF
--- a/kodosumi/service/expose/registry.py
+++ b/kodosumi/service/expose/registry.py
@@ -31,7 +31,7 @@ from kodosumi.service.expose.wallet_inventory import (WalletReport,
 logger = logging.getLogger(__name__)
 
 
-# Page size of the /wallet endpoint. The node caps `take` at 100 and its
+# Page size of the /wallet/list endpoint. The node caps `take` at 100 and its
 # cursor is inclusive, so a page repeats the row the cursor names.
 WALLET_PAGE_SIZE = 100
 MAX_WALLET_PAGES = 50
@@ -50,7 +50,7 @@ async def _list_source_selling_wallets(
     report: Optional[WalletReport] = None,
 ) -> List[Dict]:
     """
-    Read selling wallets of one payment source from the /wallet endpoint.
+    Read selling wallets of one payment source from the /wallet/list endpoint.
 
     Payment nodes used to embed SellingWallets in the /payment-source
     response and newer ones do not, so this is the fallback for sources
@@ -68,8 +68,12 @@ async def _list_source_selling_wallets(
     seen_ids = set()
     cursor_id = ""
     for _ in range(MAX_WALLET_PAGES):
+        # /wallet/list, not /wallet. The node reads /wallet as the lookup of
+        # one wallet by id, so it answers a filter-only query with
+        # "id: Invalid input: expected string, received undefined" and
+        # HTTP 400, and every selling wallet then reads as absent.
         url = (
-            f"{masumi.base_url}/wallet"
+            f"{masumi.base_url}/wallet/list"
             f"?paymentSourceId={source_id}&walletType=Selling"
             f"&take={WALLET_PAGE_SIZE}"
         )
@@ -83,7 +87,7 @@ async def _list_source_selling_wallets(
                     f"{source_id}: HTTP {resp.status_code}")
             record_problem(
                 report,
-                f"GET /wallet for payment source {source_id} answered "
+                f"GET /wallet/list for payment source {source_id} answered "
                 f"HTTP {resp.status_code}")
             logger.warning(
                 "Failed to list wallets of payment source %s: %s",
@@ -273,7 +277,7 @@ async def list_wallets(
                             "inventory") from result
                     record_problem(
                         report,
-                        f"GET /wallet for payment source "
+                        f"GET /wallet/list for payment source "
                         f"{sources[index].get('id', '')} failed: "
                         f"{describe_exception(result)}")
                     logger.warning(

--- a/tests/test_masumi_v2.py
+++ b/tests/test_masumi_v2.py
@@ -206,7 +206,7 @@ class TestListWallets:
         assert wallets[0]["note"] == ""
         assert wallets[0]["paymentSourceType"] == PAYMENT_SOURCE_TYPE_V2
         fallback_url = client.get.call_args_list[1].args[0]
-        assert "/wallet?paymentSourceId=src1" in fallback_url
+        assert "/wallet/list?paymentSourceId=src1" in fallback_url
         assert "walletType=Selling" in fallback_url
 
     @pytest.mark.asyncio

--- a/tests/test_wallet_inventory.py
+++ b/tests/test_wallet_inventory.py
@@ -92,7 +92,7 @@ class TestDescribeEmpty:
     def test_a_failed_request_warns_even_with_wallets_in_hand(self):
         report = WalletReport(
             source_count=2, matched_count=2,
-            problems=["GET /wallet for payment source src-v2 answered "
+            problems=["GET /wallet/list for payment source src-v2 answered "
                       "HTTP 503"])
         warning = report.describe_partial()
         assert "may be incomplete" in warning
@@ -150,7 +150,7 @@ class TestListWalletsReport:
         assert wallets == []
         assert report.source_count == 1
         assert report.problems == [
-            "GET /wallet for payment source src-main answered HTTP 403"]
+            "GET /wallet/list for payment source src-main answered HTTP 403"]
 
     @pytest.mark.asyncio
     async def test_a_clean_run_reports_no_problem(self):
@@ -239,7 +239,7 @@ class TestListWalletsReport:
             await list_wallets(_make_config(), report=report)
 
         assert report.problems == [
-            "GET /wallet for payment source src-main failed: ReadTimeout"]
+            "GET /wallet/list for payment source src-main failed: ReadTimeout"]
         assert report.describe_empty("Mainnet").endswith("ReadTimeout")
 
     @pytest.mark.asyncio
@@ -326,7 +326,7 @@ class TestWalletsEndpoint:
             report.source_count = 2
             report.matched_count = 2
             report.problems.append(
-                "GET /wallet for payment source src-v2 answered HTTP 503")
+                "GET /wallet/list for payment source src-v2 answered HTTP 503")
             return [{"walletVkey": "vkey-1",
                      "paymentSourceType": "Web3CardanoV1"}]
 


### PR DESCRIPTION
## Problem

Listing selling wallets always failed against every payment source that does
not embed `SellingWallets` in `/payment-source`. The operator saw:

```
No Web3CardanoV2 selling wallet could be listed. The Masumi node did not
answer every request for network 'Mainnet': GET /wallet for payment source
cmc9my9nn0003vbjyqkbs28mv answered HTTP 400
```

The node reads `GET /wallet` as the lookup of a single wallet by id. A
filter-only query is answered with:

```
HTTP 400 {"status":"error","error":{"message":"id: Invalid input: expected string, received undefined"}}
```

The paginated list lives at `GET /wallet/list`. The wrong path came in with
#88 and was never exercised against a node, because `/payment-source` had
already stopped embedding `SellingWallets`.

Both rails were affected, not only V2. The message names V2 only because the
V2 selector is what reports the empty result.

## Fix

`registry.py` now requests `/wallet/list`. The two recorded problems and the
surrounding comments name the real path, so an operator greps for what was
actually sent.

`/wallet/list` needs a read token where `/wallet` needed an admin one, so this
asks for strictly less.

No fallback to the old path is added. Nodes that lack `/wallet/list` are the
same nodes that still embed `SellingWallets` in `/payment-source`, so they
never reach this request.

## Why the suite missed it

The mock in `test_falls_back_to_wallet_endpoint` answers any URL, so the
assertion `"/wallet?paymentSourceId=src1" in fallback_url` encoded the bug
rather than catching it. It now pins `/wallet/list`.

Reverting `registry.py` alone, with the tests kept:

```
3 failed, 56 passed
FAILED tests/test_masumi_v2.py::TestListWallets::test_falls_back_to_wallet_endpoint
FAILED tests/test_wallet_inventory.py::TestListWalletsReport::test_records_a_refused_wallet_request
FAILED tests/test_wallet_inventory.py::TestListWalletsReport::test_names_an_exception_that_carries_no_message
```

## Verification

Every test file that exercises this code, on Python 3.12:

```
168 passed in 1.43s
```

End to end against the live Mainnet node, calling the patched `list_wallets`:

```
network: Mainnet
sources seen: 2 matched: 2
problems: []
wallets returned: 15
by paymentSourceType: {'Web3CardanoV2': 1, 'Web3CardanoV1': 14}
```

Before the fix the same call returned 0 wallets and one recorded problem per
payment source.

## Note for reviewers

`tests/test_expose.py` was not run to completion. It stalls partway on both
3.11 and 3.12 for reasons that predate this branch, and it contains no
reference to wallets or `list_wallets`, so it does not cover this change.
