### PR TITLE
fix(expose): make the migrate dialog's API base URL field readable

### DIFF
--- a/kodosumi/service/admin/templates/expose/_registry_styles.html
+++ b/kodosumi/service/admin/templates/expose/_registry_styles.html
@@ -124,6 +124,22 @@
         appearance: auto;
         -webkit-appearance: auto;
     }
+    /* Beer styles a text input only inside a .field wrapper, so a bare one
+       keeps the user agent's white box while inheriting the dialog's near
+       white text: whatever is typed is white on white. The dialog carries
+       its own <label> above each control, so match the select above rather
+       than adopting the floating label wrapper. */
+    .register-dialog .dialog-field > input[type="text"] {
+        background: var(--surface-variant);
+        color: var(--on-surface);
+        border: 1px solid var(--outline);
+        border-radius: 6px;
+        padding: 6px 10px;
+        font-size: 0.85rem;
+        font-family: inherit;
+        width: 100%;
+        box-sizing: border-box;
+    }
     .register-dialog .pricing-row {
         display: flex;
         gap: 10px;


### PR DESCRIPTION
## Problem

In the Migrate Agent dialog, the "API base URL (optional)" field was
unreadable. Whatever the operator typed was white text on a white box.

Beer styles a text input only as a child of a `.field` wrapper
(`.field>:is(input,textarea,select){all:unset;...}`). This was the only bare
input in the dialog, so it kept the user agent's white background while
inheriting the dialog's near white text colour.

Measured on the rendered dialog, before:

```
background rgb(255, 255, 255)
colour     rgb(230, 225, 230)
box        143 x 20 px, padding 0
```

The box was also too small. A short example URL needed 195px of the 143px
available, so even the invisible text scrolled out of view, and the 45
character placeholder was clipped to "Leave empty to keep th".

The field was functionally live throughout: the value was stored and
submitted correctly. Only the rendering was broken.

## Fix

One rule in `_registry_styles.html`, mirroring the `.register-dialog select`
rule directly above it, which exists for the same reason.

After:

```
background rgb(73, 69, 78)
colour     rgb(230, 225, 230)
box        464 x 31 px, padding 6px 10px
```

Two choices worth stating:

- The dialog prints its own `<label>` above each control, so this matches the
  neighbouring `select` rather than adopting Beer's `.field ... label`
  floating label wrapper, which would render a second label.
- The selector is scoped to a direct child of `.dialog-field` so it cannot
  reach `#dlg_amount`. That input sits inside a `.field border label` wrapper
  and must keep Beer's styling. Verified after the change: it still computes
  as `background rgba(0,0,0,0)`, `padding 0px 15px`, `150 x 48`, untouched.

## Verification

Rendered the real dialog markup against the real stylesheets, typed
`https://agents.example.com/sumi`, and confirmed the text is legible and the
placeholder is no longer clipped.

Both JavaScript suites pass:

```
node tests/test_migrate_dialog.js       -> all twenty-two dialog cases behaved as expected
node tests/test_pr88_registry_yaml_sync.js -> exit 0
```

CSS only. No template markup, no script, no Python touched.

## Noted, not addressed

In the Register dialog, the Amount field's floating label overlaps its `0.01`
value until the field takes focus. This change does not affect that, and I did
not investigate whether it reproduces in the running app.
