### PR TITLE
feat(expose): show the url a migration will mint, and require it

### DIFF
--- a/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialog_script.html
@@ -31,8 +31,8 @@ function openRegisterDialog(idx) {
     var tags = Array.isArray(parsed.tags) ? parsed.tags : [];
     document.getElementById('dlg_tags').textContent = tags.join(', ') || '(none)';
 
-    var sumiAddress = '{{ app_server }}';
-    document.getElementById('dlg_api_url').textContent = sumiAddress + '/sumi' + flowUrl;
+    document.getElementById('dlg_api_url').textContent =
+        sumiApiBaseUrl(flowUrl);
 
     // Pre-fill pricing from YAML if available
     var dlgPricingType = document.getElementById('dlg_pricing_type');
@@ -214,6 +214,60 @@ async function submitRegistration() {
 // options the second open already rendered.
 let migrateDialogGeneration = 0;
 
+// The url a buyer calls for this flow. This mirrors sumi_api_base_url()
+// on the server, which is the value a registration is minted with, so the
+// two must not drift: the migrate dialog now sends this string back and it
+// is minted verbatim. The trailing slash matters. KODO_SUMI_ADDRESS is
+// commonly written "http://host/", the server drops the slash and this used
+// to keep it, so the register dialog displayed a url with a doubled slash
+// that was not the one being minted.
+function sumiApiBaseUrl(flowUrl) {
+    var sumiAddress = '{{ app_server }}';
+    return sumiAddress.replace(/\/+$/, '') + '/sumi' + (flowUrl || '');
+}
+
+// The served url of the flow whose migrate dialog is open. Kept so the note
+// and the reset button can compare against it without deriving it twice.
+let migrateDefaultApiBaseUrl = '';
+
+// Say what an edited url costs. This kodosumi answers only on the served
+// path, so any other value has to be an agent that is already deployed
+// here; otherwise the mint is permanent and points buyers at nothing.
+function updateMigrateUrlNote() {
+    var input = document.getElementById('mig_api_base_url');
+    var note = document.getElementById('mig_api_base_url_note');
+    var text = document.getElementById('mig_api_base_url_note_text');
+    var reset = document.getElementById('mig_api_base_url_reset');
+    if (!input || !note || !text) return;
+    var value = input.value.trim();
+    var edited = true;
+    if (!value) {
+        text.textContent = 'The API base URL cannot be empty. '
+            + 'Buyers need a url to call.';
+    } else if (migrateDefaultApiBaseUrl
+               && value !== migrateDefaultApiBaseUrl) {
+        text.textContent = 'This kodosumi serves only '
+            + migrateDefaultApiBaseUrl
+            + '. Set another url only when that agent is already deployed '
+            + 'here, or buyers reach nothing.';
+    } else {
+        // The default. Say what the field is for, rather than leaving the
+        // one explanatory line to appear only once something is wrong.
+        text.textContent = 'Buyers call this url. It is the one this '
+            + 'kodosumi serves for this flow.';
+        edited = false;
+    }
+    note.className = edited ? 'dlg-caution warn' : 'dlg-caution';
+    if (reset) reset.style.display = edited ? '' : 'none';
+}
+
+function resetMigrateUrl() {
+    var input = document.getElementById('mig_api_base_url');
+    if (!input) return;
+    input.value = migrateDefaultApiBaseUrl;
+    updateMigrateUrlNote();
+}
+
 async function openMigrateDialog(idx) {
     var generation = ++migrateDialogGeneration;
     hideRegError(idx);
@@ -254,7 +308,17 @@ async function openMigrateDialog(idx) {
     var errEl = document.getElementById('mig_error');
 
     document.getElementById('mig_deregister').checked = false;
-    document.getElementById('mig_api_base_url').value = '';
+    // Prefilled rather than blank. An empty field used to mean "keep the
+    // url of the V1 listing", which the operator could not read and could
+    // not edit without retyping it. Showing the value that will be minted
+    // is the same default, spelled out.
+    var migSection = document.getElementById('registry_' + idx);
+    migrateDefaultApiBaseUrl = migSection
+        ? sumiApiBaseUrl(migSection.dataset ? migSection.dataset.flowUrl : '')
+        : '';
+    document.getElementById('mig_api_base_url').value =
+        migrateDefaultApiBaseUrl;
+    updateMigrateUrlNote();
     submitBtn.disabled = true;
     errEl.style.display = 'none';
     document.getElementById('migrate-dialog').showModal();
@@ -332,6 +396,26 @@ async function submitMigration() {
     var errEl = document.getElementById('mig_error');
     var metaYaml = textarea ? textarea.value : '';
     var etag = document.getElementById('etag');
+
+    // Refuse an empty url before anything is spent. The field is prefilled
+    // with the served url, so empty means the operator cleared it. The
+    // server still accepts an empty value and falls back to the same url,
+    // for older clients and direct API callers, but a blank field in front
+    // of a permanent mint is a question, not an instruction.
+    var apiBaseUrl = document.getElementById('mig_api_base_url').value.trim();
+    if (!apiBaseUrl) {
+        updateMigrateUrlNote();
+        errEl.style.display = 'block';
+        errEl.style.color = '';
+        errEl.textContent = 'The API base URL cannot be empty. '
+            + 'Use the served url, or type the url of the deployment that '
+            + 'serves the V2 agent.';
+        return;
+    }
+    // Anything past empty is the server's call. It reads the url the way a
+    // buyer's client will, and a second parser here would only disagree
+    // with it. Its refusal is already shown in this dialog.
+
     var generation = beginRegistryRequest(idx);
 
     submitBtn.disabled = true;
@@ -346,8 +430,7 @@ async function submitMigration() {
                 flow_url: flowUrl,
                 wallet_vkey: walletSelect.value,
                 deregister_previous: document.getElementById('mig_deregister').checked,
-                api_base_url:
-                    document.getElementById('mig_api_base_url').value.trim(),
+                api_base_url: apiBaseUrl,
                 meta_yaml: metaYaml,
                 meta_etag: etag ? etag.value : null
             })

--- a/kodosumi/service/admin/templates/expose/_registry_dialogs.html
+++ b/kodosumi/service/admin/templates/expose/_registry_dialogs.html
@@ -30,14 +30,24 @@
             <select id="mig_wallet"></select>
         </div>
         <div class="dialog-field">
-            <label>API base URL (optional)</label>
+            <label for="mig_api_base_url">API base URL</label>
             <input type="text" id="mig_api_base_url"
-                   placeholder="Leave empty to keep the URL of the V1 listing">
-            <div class="dialog-readonly" style="font-size: 0.75rem;">
-                The new agent advertises the same URL as the V1 listing unless
-                you set one here. Only set it when another deployment serves
-                the V2 agent: this kodosumi answers on its own path, so a
-                different value is minted on chain and sends buyers elsewhere.
+                   oninput="updateMigrateUrlNote()"
+                   aria-required="true"
+                   aria-describedby="mig_api_base_url_note"
+                   placeholder="https://host/sumi/flow">
+            <!-- One line, always true of what the field currently holds.
+                 A fixed helper saying the field is filled with the served
+                 url turns into a lie the moment the operator edits it.
+                 aria-live, because the line is the only thing that changes
+                 when the operator edits a url they cannot see the effect
+                 of until the mint is already permanent. -->
+            <div class="dlg-caution" id="mig_api_base_url_note"
+                 aria-live="polite">
+                <span id="mig_api_base_url_note_text"></span>
+                <button type="button" class="small border"
+                        id="mig_api_base_url_reset" style="display: none;"
+                        onclick="resetMigrateUrl()">Use the served url</button>
             </div>
         </div>
         <div class="dialog-field">

--- a/kodosumi/service/admin/templates/expose/_registry_styles.html
+++ b/kodosumi/service/admin/templates/expose/_registry_styles.html
@@ -157,5 +157,40 @@
         color: var(--error);
         padding: 8px 0;
     }
+    /* The one line under the API base URL field. It is always present, so
+       the plain form is quiet: it explains what the field is for. The .warn
+       form marks the states the operator has to act on, without borrowing
+       .dlg-error, which reads as a request that already failed. */
+    .register-dialog .dlg-caution {
+        font-size: 0.75rem;
+        color: var(--on-surface-variant);
+        border-inline-start: 2px solid var(--outline-variant);
+        padding: 4px 0 4px 10px;
+        margin-top: 6px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+    .register-dialog .dlg-caution.warn {
+        border-inline-start-color: var(--error);
+    }
+    .register-dialog .dlg-caution > span {
+        flex: 1;
+        min-width: 200px;
+        line-height: 1.45;
+    }
+    /* Quiet on purpose. This is the way back from a mistake, not the action
+       of the dialog: a filled button here outshouted Migrate Agent. */
+    .register-dialog .dlg-caution > button {
+        flex: none;
+        font-size: 0.7rem;
+        block-size: 1.75rem;
+        padding-inline: 0.75rem;
+        text-transform: none;
+        background: transparent;
+        color: var(--on-surface-variant);
+        border-color: var(--outline);
+    }
 </style>
 <script src="/static/js-yaml.min.js"></script>

--- a/tests/test_migrate_dialog.js
+++ b/tests/test_migrate_dialog.js
@@ -25,7 +25,13 @@ assert.notEqual(start, -1);
 // that loads only the first half cannot see the field leave the page.
 const end = dialogSource.indexOf('\nasync function deregisterPrevious(', start);
 assert.ok(end > start);
-const openSource = dialogSource.slice(start, end);
+// The slice carries the Jinja placeholder for the sumi address. Give it a
+// real value, so the url assertions below read as the urls an operator
+// sees, and so the trailing slash the server strips is actually exercised.
+const SUMI_ADDRESS = 'http://node.example/';
+const SERVED_URL = 'http://node.example/sumi/meme-copy';
+const openSource = dialogSource.slice(start, end)
+    .replace("'{{ app_server }}'", JSON.stringify(SUMI_ADDRESS));
 
 // The real generation helpers, not stubs. Stubs that ignore their
 // arguments cannot see submitMigration passing the wrong idx or losing
@@ -74,6 +80,13 @@ async function open(responder) {
         mig_error: makeElement(),
         mig_deregister: makeElement(),
         mig_api_base_url: makeElement(),
+        mig_api_base_url_note: makeElement(),
+        mig_api_base_url_note_text: makeElement(),
+        mig_api_base_url_reset: makeElement(),
+        // The section carries the flow path the served url is built from.
+        // Without a dataset the dialog cannot derive a url at all, and a
+        // prefill assertion would pass on an empty string.
+        registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
         'migrate-dialog': makeElement(),
     };
     const infoLines = [];
@@ -174,16 +187,20 @@ function jsonResponse(payload) {
     assert.match(run.elements.mig_error.textContent, /HTTP 502/);
     assert.doesNotMatch(run.elements.mig_error.textContent, /Add one in the/);
 
-    // 5. The url override starts empty on every open. A fresh element is
-    //    empty anyway, so type into it and reopen: only a real reset can
-    //    clear it. A url left over from an abandoned dialog would be
-    //    minted on chain by the next migration.
+    // 5. The url field is reset to the served url on every open, not to
+    //    empty. Type something else into it and reopen: a url left over
+    //    from an abandoned dialog would otherwise be minted on chain by
+    //    the next migration, and that mint cannot be taken back.
     {
         const elements = {
             mig_current_agent: makeElement(), mig_pricing: makeElement(),
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const context = {
@@ -209,7 +226,7 @@ function jsonResponse(payload) {
         await context.openMigrateDialog(0);
         console.log('\n5. url override after a reopen:',
                     JSON.stringify(elements.mig_api_base_url.value));
-        assert.equal(elements.mig_api_base_url.value, '');
+        assert.equal(elements.mig_api_base_url.value, SERVED_URL);
         assert.equal(elements.mig_deregister.checked, false);
     }
 
@@ -221,6 +238,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const v2 = {wallets: [{walletVkey: 'vkey-v2-bbbbbb',
@@ -291,6 +312,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const info = makeElement();
@@ -357,6 +382,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const info = makeElement();
@@ -457,6 +486,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         let call = 0;
@@ -511,6 +544,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const pageInfo = makeElement();
@@ -579,6 +616,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         let releaseFirst;
@@ -717,6 +758,9 @@ function jsonResponse(payload) {
         vm.runInContext(
             helpersSource + '\n' + walletsSource + '\n' + openSource,
             context);
+        // The dialog prefills this on open. These cases call the submit directly,
+        // so fill it the way an operator would have found it.
+        elements.mig_api_base_url.value = SERVED_URL;
         await context.submitMigration();
         console.log('\n16. the network drops mid-submit');
         console.log('   dialog :', elements.mig_error.textContent);
@@ -740,6 +784,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         const context = {
@@ -842,6 +890,9 @@ function jsonResponse(payload) {
         vm.runInContext(
             helpersSource + '\n' + walletsSource + '\n' + openSource,
             context);
+        // The dialog prefills this on open. These cases call the submit directly,
+        // so fill it the way an operator would have found it.
+        elements.mig_api_base_url.value = SERVED_URL;
         const submitting = context.submitMigration();
         context.activeDialogIdx = null;              // Escape
         elements['migrate-dialog'].close();
@@ -957,6 +1008,10 @@ function jsonResponse(payload) {
             mig_wallet: makeElement(), mig_submit: makeElement(),
             mig_error: makeElement(), mig_deregister: makeElement(),
             mig_api_base_url: makeElement(),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
             'migrate-dialog': makeElement(),
         };
         let call = 0;
@@ -1000,5 +1055,100 @@ function jsonResponse(payload) {
         assert.equal(elements.mig_submit.disabled, false);
     }
 
-    console.log('\nall twenty-two dialog cases behaved as expected');
+    // 23. The field opens on the served url, with the address's trailing
+    //     slash gone. The server strips it before it mints, and this value
+    //     is now sent back and minted verbatim, so a doubled slash here
+    //     would become the url on chain.
+    {
+        const run = await open(() => jsonResponse({wallets: [
+            {walletVkey: 'vkey-v2-bbbbbb', walletAddress: 'addr2',
+             note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'},
+        ]}));
+        console.log('\n23. the field opens on the served url');
+        console.log('   value:', JSON.stringify(run.elements.mig_api_base_url.value));
+        console.log('   note :', JSON.stringify(run.elements.mig_api_base_url_note_text.textContent));
+        console.log('   class:', JSON.stringify(run.elements.mig_api_base_url_note.className));
+        assert.equal(run.elements.mig_api_base_url.value, SERVED_URL);
+        assert.doesNotMatch(run.elements.mig_api_base_url.value, /\/\/sumi/);
+        // The line explains the field while the value is still the default,
+        // and carries no warning mark.
+        assert.equal(run.elements.mig_api_base_url_note.className, 'dlg-caution');
+        assert.match(run.elements.mig_api_base_url_note_text.textContent,
+                     /Buyers call this url/);
+        assert.equal(run.elements.mig_api_base_url_reset.style.display, 'none');
+    }
+
+    // 24. An emptied field stops the submit before anything is spent, and
+    //     says so. The server would fall back to the served url, so this is
+    //     the only place the blank is read as a question.
+    {
+        let fetched = false;
+        const elements = {
+            mig_current_agent: makeElement(), mig_pricing: makeElement(),
+            mig_wallet: makeElement({value: 'vkey-v2-bbbbbb'}),
+            mig_submit: makeElement(), mig_error: makeElement(),
+            mig_deregister: makeElement(),
+            mig_api_base_url: makeElement({value: '   '}),
+            mig_api_base_url_note: makeElement(),
+            mig_api_base_url_note_text: makeElement(),
+            mig_api_base_url_reset: makeElement(),
+            registry_0: makeElement({dataset: {flowUrl: '/meme-copy'}}),
+            'migrate-dialog': makeElement(),
+        };
+        const context = {
+            console, exposeName: 'meme-copy', activeDialogIdx: 0,
+            hideRegError() {}, showRegError() {},
+            jsyaml: {load: () => ({})},
+            fetch: async () => { fetched = true; return jsonResponse({}); },
+            document: {
+                querySelector: () => ({value: ''}),
+                querySelectorAll: () => [],
+                getElementById: (id) => elements[id] || null,
+                createElement: () => makeElement(),
+            },
+        };
+        vm.createContext(context);
+        vm.runInContext(
+            helpersSource + '\n' + walletsSource + '\n' + openSource, context);
+        await context.submitMigration();
+        console.log('\n24. an empty url stops the submit');
+        console.log('   fetched:', fetched);
+        console.log('   error  :', elements.mig_error.textContent);
+        assert.equal(fetched, false);
+        assert.match(elements.mig_error.textContent, /cannot be empty/);
+        assert.equal(elements.mig_error.style.display, 'block');
+        // The button must stay usable: the operator has to be able to put a
+        // url back and submit again.
+        assert.equal(elements.mig_submit.disabled, false);
+    }
+
+    // 25. A url that is not the served one is minted as typed, so the
+    //     dialog names what this kodosumi actually answers on, and offers
+    //     the way back.
+    {
+        const run = await open(() => jsonResponse({wallets: [
+            {walletVkey: 'vkey-v2-bbbbbb', walletAddress: 'addr2',
+             note: 'v2 seller', paymentSourceType: 'Web3CardanoV2'},
+        ]}));
+        run.elements.mig_api_base_url.value = 'https://elsewhere.example/sumi/x';
+        run.context.updateMigrateUrlNote();
+        console.log('\n25. an edited url is cautioned, then reset');
+        console.log('   note   :', run.elements.mig_api_base_url_note_text.textContent);
+        assert.equal(run.elements.mig_api_base_url_note.className,
+                     'dlg-caution warn');
+        assert.equal(run.elements.mig_api_base_url_reset.style.display, '');
+        assert.match(run.elements.mig_api_base_url_note_text.textContent,
+                     /serves only http:\/\/node\.example\/sumi\/meme-copy/);
+        assert.match(run.elements.mig_api_base_url_note_text.textContent,
+                     /already deployed here/);
+
+        run.context.resetMigrateUrl();
+        console.log('   after reset:',
+                    JSON.stringify(run.elements.mig_api_base_url.value));
+        assert.equal(run.elements.mig_api_base_url.value, SERVED_URL);
+        assert.equal(run.elements.mig_api_base_url_note.className, 'dlg-caution');
+        assert.equal(run.elements.mig_api_base_url_reset.style.display, 'none');
+    }
+
+    console.log('\nall twenty-five dialog cases behaved as expected');
 })();


### PR DESCRIPTION
## Why

The "API base URL (optional)" field in the migrate dialog opened blank, and
blank meant "keep the url of the V1 listing". The operator could not read the
value that was about to be minted on chain, and changing it meant retyping a
url they had never been shown.

It now opens on that url.

## What a buyer reaches, for context

The url is derived, not free-form:

```python
def sumi_api_base_url(sumi_address: str, flow_url: str) -> str:
    return f"{sumi_address.rstrip('/')}/sumi{flow_url}"
```

One flow, one endpoint, and the runner reads a single `agentIdentifier` from
the flow metadata. Migration swaps it once the V2 mint confirms. So a buyer
connecting to the url always reaches the same MIP-003 endpoint, and after the
switch every job is priced and paid on V2, including for a buyer who found the
V1 listing.

## Changes

**One derivation, shared.** Both dialogs now call `sumiApiBaseUrl()`, which
mirrors `sumi_api_base_url()` on the server. The field is now always sent, so
what it holds is minted verbatim and the browser must not derive it a second,
different way.

This fixes a second bug. The register dialog built the url inline without
stripping the address:

```js
var sumiAddress = '{{ app_server }}';
document.getElementById('dlg_api_url').textContent = sumiAddress + '/sumi' + flowUrl;
```

With `KODO_SUMI_ADDRESS` written `http://host/`, that displayed
`http://host//sumi/flow` while the server minted `http://host/sumi/flow`. The
doubled slash still resolves, so it was only ever a wrong display, but with a
required field it would have become the minted value.

**Required.** An empty field stops the submit before anything is spent. The
server still accepts an empty `api_base_url` and falls back to the served url,
for direct API callers and older clients, so this is a dialog rule only.

Nothing past empty is validated in the browser. The server reads the url the
way a buyer's client will, deliberately and with a long rationale, and a second
parser here would only disagree with it. Its refusal already surfaces in this
dialog.

**One line under the field, always true.** The fixed helper text claimed the
field held the served url, which became false the moment anyone edited it. It
is replaced by a single line with three states:

| State | Line |
| --- | --- |
| Default | Buyers call this url. It is the one this kodosumi serves for this flow. |
| Edited | This kodosumi serves only `<served url>`. Set another url only when that agent is already deployed here, or buyers reach nothing. |
| Empty | The API base URL cannot be empty. Buyers need a url to call. |

The last two also offer **Use the served url**, styled quietly on purpose: it
is the way back from a mistake, not the action of the dialog.

## Why a url this kodosumi does not serve is dangerous

Measured against a live node, on a deployed flow and the same path with a
suffix:

```
GET /sumi/ad-anim-copy/availability     -> 200
GET /sumi/ad-anim-copy/input_schema     -> 200

GET /sumi/ad-anim-copy-v2/availability  -> 200  {"status":"unavailable",
                                                 "message":"Service 'ad-anim-copy-v2' not found or not available"}
GET /sumi/ad-anim-copy-v2/input_schema  -> 404
```

An undeployed url does not fail loudly. `/availability` answers HTTP 200, so a
status-code health check reports the agent as fine, and only the real calls
404. The mint is permanent, which is why the dialog names the served url rather
than letting the operator discover this afterwards.

## Tests

25 dialog cases, up from 22. The three new ones cover the prefill (including
that the address's trailing slash is gone), the empty submit being stopped
with nothing fetched, and the edited-url line plus its reset.

Reverting `_registry_dialog_script.html` and keeping the tests fails case 5
with `actual: ''`, so the prefill is genuinely pinned rather than passing on an
empty string.

`test_pr88_registry_yaml_sync.js` and `test_pr88_registry_yaml_sync.py` both
pass.

The dialog was also driven in a browser against the real stylesheets: typing a
suffixed url raised the caution, reset restored the served url, and emptying
the field produced the required message. All three matched the unit tests.

## Not changed

`migrate_control.py`. The API contract is unchanged.
